### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "near-openapi-client"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "near-openapi-types"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/polyprogrammist/near-openapi-client"
@@ -10,4 +10,4 @@ resolver = "2"
 
 [workspace.dependencies]
 near-openapi-client = { path = "near-openapi-client" }
-near-openapi-types = { path = "near-openapi-types", version = "0.2.1" }
+near-openapi-types = { path = "near-openapi-types", version = "0.3.0" }

--- a/near-openapi-client/CHANGELOG.md
+++ b/near-openapi-client/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-client-v0.2.1...near-openapi-client-v0.3.0) - 2025-07-08
+
+### Other
+
+- update docs
+- add docs
+- add docs for client crate main
+- schemars 1.0.3
+- string
+- tmp
+- cargo fmt in client and types, remove pub use of types internals in client
+
 ## [0.1.2](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-client-v0.1.1...near-openapi-client-v0.1.2) - 2025-06-24
 
 ### Other

--- a/near-openapi-types/CHANGELOG.md
+++ b/near-openapi-types/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-types-v0.2.1...near-openapi-types-v0.3.0) - 2025-07-08
+
+### Other
+
+- updates docs
+- add docs
+- update RpcStateChangesInBlockByTypeRequest
+- titles from nearcore
+- schemars 1.0.3
+- block id and chunk request, use openapi generated without progenitor feature
+- add title
+- viewaccountbyfinality
+- cargo fmt in client and types, remove pub use of types internals in client
+
 ## [0.2.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-types-v0.1.1...near-openapi-types-v0.2.0) - 2025-06-24
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `near-openapi-types`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `near-openapi-client`: 0.2.1 -> 0.3.0 (✓ API compatible changes)

### ⚠ `near-openapi-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RpcClientConfigResponse.save_invalid_witnesses in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:17391
  field RpcClientConfigResponse.save_tx_outcomes in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:17397
  field VmConfigView.reftypes_bulk_memory in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:28863

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant0ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21078
  enum near_openapi_types::RpcQueryRequestVariant8RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19876
  enum near_openapi_types::RpcQueryRequestVariant22RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19292
  enum near_openapi_types::RpcQueryRequestVariant10RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18352
  enum near_openapi_types::StateChangeValueViewType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24689
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant3ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21686
  enum near_openapi_types::RpcQueryRequestVariant11RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18424
  enum near_openapi_types::RpcQueryRequestVariant13RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18568
  enum near_openapi_types::RpcQueryRequestVariant1RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19076
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant9ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:22142
  enum near_openapi_types::RpcQueryRequestVariant4RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19584
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant10ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21154
  enum near_openapi_types::RpcQueryRequestVariant6RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19728
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant13ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21382
  enum near_openapi_types::RpcQueryRequestVariant9RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19948
  enum near_openapi_types::RpcQueryRequestVariant23RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19364
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant4ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21762
  enum near_openapi_types::RpcQueryRequestVariant12RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18496
  enum near_openapi_types::NameRpcErrorKind, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:13974
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant6ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21914
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant7ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21990
  enum near_openapi_types::RpcQueryRequestVariant14RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18640
  enum near_openapi_types::RpcQueryRequestVariant16RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18788
  enum near_openapi_types::RpcQueryRequestVariant18RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18932
  enum near_openapi_types::RpcQueryRequestVariant19RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19004
  enum near_openapi_types::RpcQueryRequestVariant7RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19800
  enum near_openapi_types::TypeTransactionOrReceiptId, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:25753
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant14ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21458
  enum near_openapi_types::RpcQueryRequestVariant21RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19220
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant1ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21534
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant2ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21610
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant5ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21838
  enum near_openapi_types::RpcQueryRequestVariant0RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18280
  enum near_openapi_types::RpcQueryRequestVariant2RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19440
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant8ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:22066
  enum near_openapi_types::RpcQueryRequestVariant15RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18712
  enum near_openapi_types::RpcQueryRequestVariant3RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19512
  enum near_openapi_types::RpcQueryRequestVariant17RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18860
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant11ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21230
  enum near_openapi_types::RpcQueryRequestVariant5RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19656
  enum near_openapi_types::RpcStateChangesInBlockByTypeRequestVariant12ChangesType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21306
  enum near_openapi_types::RpcQueryRequestVariant20RequestType, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:19148

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant BlockId:BlockHeight in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:3637
  variant BlockId:CryptoHash in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:3638
  variant RpcStateChangesInBlockByTypeRequest:AccountChangesByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21364
  variant RpcStateChangesInBlockByTypeRequest:SingleAccessKeyChangesByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21369
  variant RpcStateChangesInBlockByTypeRequest:SingleGasKeyChangesByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21374
  variant RpcStateChangesInBlockByTypeRequest:AllAccessKeyChangesByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21379
  variant RpcStateChangesInBlockByTypeRequest:AllGasKeyChangesByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21384
  variant RpcStateChangesInBlockByTypeRequest:ContractCodeChangesByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21389
  variant RpcStateChangesInBlockByTypeRequest:DataChangesByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21394
  variant RpcStateChangesInBlockByTypeRequest:AccountChangesByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21400
  variant RpcStateChangesInBlockByTypeRequest:SingleAccessKeyChangesByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21405
  variant RpcStateChangesInBlockByTypeRequest:SingleGasKeyChangesByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21410
  variant RpcStateChangesInBlockByTypeRequest:AllAccessKeyChangesByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21415
  variant RpcStateChangesInBlockByTypeRequest:AllGasKeyChangesByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21420
  variant RpcStateChangesInBlockByTypeRequest:ContractCodeChangesByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21425
  variant RpcStateChangesInBlockByTypeRequest:DataChangesByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21430
  variant RpcStateChangesInBlockByTypeRequest:AccountChangesBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21436
  variant RpcStateChangesInBlockByTypeRequest:SingleAccessKeyChangesBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21441
  variant RpcStateChangesInBlockByTypeRequest:SingleGasKeyChangesBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21446
  variant RpcStateChangesInBlockByTypeRequest:AllAccessKeyChangesBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21451
  variant RpcStateChangesInBlockByTypeRequest:AllGasKeyChangesBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21456
  variant RpcStateChangesInBlockByTypeRequest:ContractCodeChangesBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21461
  variant RpcStateChangesInBlockByTypeRequest:DataChangesBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:21466
  variant RpcChunkRequest:BlockShardId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:16704
  variant RpcChunkRequest:ChunkHash in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:16708
  variant RpcQueryRequest:ViewAccountByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20012
  variant RpcQueryRequest:ViewCodeByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20017
  variant RpcQueryRequest:ViewStateByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20022
  variant RpcQueryRequest:ViewAccessKeyByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20030
  variant RpcQueryRequest:ViewAccessKeyListByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20036
  variant RpcQueryRequest:CallFunctionByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20041
  variant RpcQueryRequest:ViewGlobalContractCodeByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20048
  variant RpcQueryRequest:ViewGlobalContractCodeByAccountIdByBlockId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20053
  variant RpcQueryRequest:ViewAccountByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20058
  variant RpcQueryRequest:ViewCodeByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20063
  variant RpcQueryRequest:ViewStateByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20068
  variant RpcQueryRequest:ViewAccessKeyByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20076
  variant RpcQueryRequest:ViewAccessKeyListByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20082
  variant RpcQueryRequest:CallFunctionByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20087
  variant RpcQueryRequest:ViewGlobalContractCodeByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20094
  variant RpcQueryRequest:ViewGlobalContractCodeByAccountIdByFinality in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20099
  variant RpcQueryRequest:ViewAccountBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20104
  variant RpcQueryRequest:ViewCodeBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20109
  variant RpcQueryRequest:ViewStateBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20114
  variant RpcQueryRequest:ViewAccessKeyBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20122
  variant RpcQueryRequest:ViewAccessKeyListBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20128
  variant RpcQueryRequest:CallFunctionBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20133
  variant RpcQueryRequest:ViewGlobalContractCodeBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20140
  variant RpcQueryRequest:ViewGlobalContractCodeByAccountIdBySyncCheckpoint in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:20145
  variant RpcCongestionLevelRequest:BlockShardId in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:17488
  variant RpcCongestionLevelRequest:ChunkHash in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:17492
  variant VmKind:NearVm2 in /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:28946

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_missing.ron

Failed in:
  variant RpcStateChangesInBlockByTypeRequest::Variant0, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:20969
  variant RpcStateChangesInBlockByTypeRequest::Variant1, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:20974
  variant RpcStateChangesInBlockByTypeRequest::Variant2, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:20979
  variant RpcStateChangesInBlockByTypeRequest::Variant3, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:20984
  variant RpcStateChangesInBlockByTypeRequest::Variant4, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:20989
  variant RpcStateChangesInBlockByTypeRequest::Variant5, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:20995
  variant RpcStateChangesInBlockByTypeRequest::Variant6, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21000
  variant RpcStateChangesInBlockByTypeRequest::Variant7, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21005
  variant RpcStateChangesInBlockByTypeRequest::Variant8, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21010
  variant RpcStateChangesInBlockByTypeRequest::Variant9, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21015
  variant RpcStateChangesInBlockByTypeRequest::Variant10, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21021
  variant RpcStateChangesInBlockByTypeRequest::Variant11, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21026
  variant RpcStateChangesInBlockByTypeRequest::Variant12, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21031
  variant RpcStateChangesInBlockByTypeRequest::Variant13, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21036
  variant RpcStateChangesInBlockByTypeRequest::Variant14, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:21041
  variant RpcQueryRequest::Variant0, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18111
  variant RpcQueryRequest::Variant1, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18116
  variant RpcQueryRequest::Variant2, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18121
  variant RpcQueryRequest::Variant3, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18129
  variant RpcQueryRequest::Variant4, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18135
  variant RpcQueryRequest::Variant5, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18140
  variant RpcQueryRequest::Variant6, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18147
  variant RpcQueryRequest::Variant7, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18152
  variant RpcQueryRequest::Variant8, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18157
  variant RpcQueryRequest::Variant9, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18162
  variant RpcQueryRequest::Variant10, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18167
  variant RpcQueryRequest::Variant11, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18175
  variant RpcQueryRequest::Variant12, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18181
  variant RpcQueryRequest::Variant13, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18186
  variant RpcQueryRequest::Variant14, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18193
  variant RpcQueryRequest::Variant15, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18198
  variant RpcQueryRequest::Variant16, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18203
  variant RpcQueryRequest::Variant17, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18208
  variant RpcQueryRequest::Variant18, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18213
  variant RpcQueryRequest::Variant19, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18221
  variant RpcQueryRequest::Variant20, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18227
  variant RpcQueryRequest::Variant21, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18232
  variant RpcQueryRequest::Variant22, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18239
  variant RpcQueryRequest::Variant23, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:18244
  variant RpcCongestionLevelRequest::Variant0, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:16028
  variant RpcCongestionLevelRequest::Variant1, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:16032
  variant BlockId::Variant0, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:2931
  variant BlockId::Variant1, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:2932
  variant RpcChunkRequest::Variant0, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:15250
  variant RpcChunkRequest::Variant1, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:15254

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct near_openapi_types::StateChangeValueViewContentSubtype0, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24396
  struct near_openapi_types::StateChangeValueViewContentSubtype3, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24508
  struct near_openapi_types::StateChangeValueViewContentSubtype6, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24618
  struct near_openapi_types::StateChangeValueViewContent, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24254
  struct near_openapi_types::CauseRpcErrorKind, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:3133
  struct near_openapi_types::StateChangeValueViewContentSubtype1, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24436
  struct near_openapi_types::StateChangeValueViewContentSubtype4, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24548
  struct near_openapi_types::StateChangeValueViewContentSubtype7, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24648
  struct near_openapi_types::StateChangeValueViewContentSubtype2, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24473
  struct near_openapi_types::StateChangeValueViewContentSubtype5, previously in file /tmp/.tmpABUS0F/near-openapi-types/src/lib.rs:24584

--- failure struct_with_pub_fields_changed_type: struct with pub fields became an enum or union ---

Description:
A struct with pub fields became an enum or union, breaking accesses to its public fields.
        ref: https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_with_pub_fields_changed_type.ron

Failed in:
  struct near_openapi_types::RpcError became enum in file /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:17615
  struct near_openapi_types::StateChangeWithCauseView became enum in file /tmp/.tmpJFBrqa/near-openapi-client/near-openapi-types/src/lib.rs:24187
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-openapi-types`

<blockquote>

## [0.3.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-types-v0.2.1...near-openapi-types-v0.3.0) - 2025-07-08

### Other

- updates docs
- add docs
- update RpcStateChangesInBlockByTypeRequest
- titles from nearcore
- schemars 1.0.3
- block id and chunk request, use openapi generated without progenitor feature
- add title
- viewaccountbyfinality
- cargo fmt in client and types, remove pub use of types internals in client
</blockquote>

## `near-openapi-client`

<blockquote>

## [0.3.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-client-v0.2.1...near-openapi-client-v0.3.0) - 2025-07-08

### Other

- update docs
- add docs
- add docs for client crate main
- schemars 1.0.3
- string
- tmp
- cargo fmt in client and types, remove pub use of types internals in client
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).