### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,16 +448,16 @@ dependencies = [
 
 [[package]]
 name = "near-gas"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a1951e112f1e8fee9142152e628778b277bee6d88cfe9ed7d40a287c957651"
+checksum = "41ca4044222f2f392ab61d27d0aefc5106b1ece4dcd22c5c987e3c75371d2a37"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "near-openapi-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -472,18 +472,28 @@ dependencies = [
 
 [[package]]
 name = "near-openapi-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
  "futures-core",
  "near-account-id",
  "near-gas",
+ "near-token",
  "progenitor-client",
  "reqwest",
  "serde",
  "serde_json",
  "serde_urlencoded",
+]
+
+[[package]]
+name = "near-token"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133a293baa70b78db8c4325753ca8012f84e67de6c84c013960722a937985615"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/polyprogrammist/near-openapi-client"
@@ -10,4 +10,4 @@ resolver = "2"
 
 [workspace.dependencies]
 near-openapi-client = { path = "near-openapi-client" }
-near-openapi-types = { path = "near-openapi-types", version = "0.3.0" }
+near-openapi-types = { path = "near-openapi-types", version = "0.4.0" }

--- a/near-openapi-client/CHANGELOG.md
+++ b/near-openapi-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-client-v0.3.0...near-openapi-client-v0.4.0) - 2025-09-28
+
+### Other
+
+- Uses NearGas, updates spec
+
 ## [0.3.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-client-v0.2.1...near-openapi-client-v0.3.0) - 2025-07-08
 
 ### Other

--- a/near-openapi-types/CHANGELOG.md
+++ b/near-openapi-types/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-types-v0.3.0...near-openapi-types-v0.4.0) - 2025-09-28
+
+### Added
+
+- introduce NearToken ([#16](https://github.com/PolyProgrammist/near-openapi-client/pull/16))
+
+### Fixed
+
+- remove Action schema from OpenAPI spec
+- apply NonDelegateAction schema change from nearcore PR #14061
+
+### Other
+
+- Uses NearGas, updates spec
+
 ## [0.3.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-types-v0.2.1...near-openapi-types-v0.3.0) - 2025-07-08
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `near-openapi-types`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `near-openapi-client`: 0.3.0 -> 0.4.0 (✓ API compatible changes)

### ⚠ `near-openapi-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field LimitConfig.max_elements_per_contract_table in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:15756
  field LimitConfig.max_tables_per_contract in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:15793
  field StateSyncConfig.concurrency in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:26806
  field StateSyncConfig.parts_compression_lvl in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:26812
  field VmConfigView.deterministic_account_ids in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:30022
  field RpcClientConfigResponse.chunk_validation_threads in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:18394
  field RpcClientConfigResponse.cloud_archival_reader in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:18401
  field RpcClientConfigResponse.cloud_archival_writer in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:18404
  field RpcClientConfigResponse.protocol_version_check in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:18452
  field RpcClientConfigResponse.save_untracked_partial_chunks_parts in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:18466
  field RpcClientConfigResponse.state_request_server_threads in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:18470
  field RpcClientConfigResponse.state_request_throttle_period in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:18472
  field RpcClientConfigResponse.state_requests_per_throttle_period in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:18474

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_missing.ron

Failed in:
  enum near_openapi_types::Action, previously in file /tmp/.tmpzYao8R/near-openapi-types/src/lib.rs:1030

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant PrepareError:TooManyTables in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:16865
  variant PrepareError:TooManyTableElements in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:16867
  variant ActionView:DeterministicStateInit in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:2064
  variant ActionsValidationError:InvalidDeterministicStateInitReceiver in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:2521
  variant ActionsValidationError:DeterministicStateInitKeyLengthExceeded in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:2525
  variant ActionsValidationError:DeterministicStateInitValueLengthExceeded in /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:2529

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_missing.ron

Failed in:
  variant VmKind::NearVm2, previously in file /tmp/.tmpzYao8R/near-openapi-types/src/lib.rs:28946

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field view_client_throttle_period of struct RpcClientConfigResponse, previously in file /tmp/.tmpzYao8R/near-openapi-types/src/lib.rs:17437

--- failure struct_with_pub_fields_changed_type: struct with pub fields became an enum or union ---

Description:
A struct with pub fields became an enum or union, breaking accesses to its public fields.
        ref: https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_with_pub_fields_changed_type.ron

Failed in:
  struct near_openapi_types::NonDelegateAction became enum in file /tmp/.tmpfKLUhx/near-openapi-client/near-openapi-types/src/lib.rs:16468
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-openapi-types`

<blockquote>

## [0.4.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-types-v0.3.0...near-openapi-types-v0.4.0) - 2025-09-28

### Added

- introduce NearToken ([#16](https://github.com/PolyProgrammist/near-openapi-client/pull/16))

### Fixed

- remove Action schema from OpenAPI spec
- apply NonDelegateAction schema change from nearcore PR #14061

### Other

- Uses NearGas, updates spec
</blockquote>

## `near-openapi-client`

<blockquote>

## [0.4.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-client-v0.3.0...near-openapi-client-v0.4.0) - 2025-09-28

### Other

- Uses NearGas, updates spec
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).