### PR TITLE
fix: regenerate types from Dec 23 OpenAPI spec

### DIFF
--- a/example/tests/global_contract_identifier.rs
+++ b/example/tests/global_contract_identifier.rs
@@ -1,29 +1,36 @@
 use near_openapi_client::types;
 
 #[test]
-fn test_global_contract_identifier_view_from_string() {
-    // This is what the RPC returns for GlobalContractIdentifierView (an AccountId)
-    let json = r#""mt_receiver_global.sandbox""#;
+fn test_global_contract_identifier_view_account_id() {
+    let json = r#"{"account_id":"mt_receiver_global.sandbox"}"#;
 
     let result: Result<types::GlobalContractIdentifierView, _> = serde_json::from_str(json);
 
-    println!("{:?}", result);
+    assert!(
+        result.is_ok(),
+        "Failed to deserialize GlobalContractIdentifierView from account_id: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_global_contract_identifier_view_hash() {
+    let json = r#"{"hash":"11111111111111111111111111111111"}"#;
+
+    let result: Result<types::GlobalContractIdentifierView, _> = serde_json::from_str(json);
 
     assert!(
         result.is_ok(),
-        "Failed to deserialize GlobalContractIdentifierView from bare string: {:?}",
+        "Failed to deserialize GlobalContractIdentifierView from hash: {:?}",
         result.err()
     );
 }
 
 #[test]
 fn test_deterministic_state_init_action_view() {
-    // This is the actual JSON returned by the RPC for a DeterministicStateInit action
-    let json = r#"{"DeterministicStateInit":{"code":"mt_receiver_global.sandbox","data":{},"deposit":"0"}}"#;
+    let json = r#"{"DeterministicStateInit":{"code":{"account_id":"mt_receiver_global.sandbox"},"data":{},"deposit":"0"}}"#;
 
     let result: Result<types::ActionView, _> = serde_json::from_str(json);
-
-    println!("{:?}", result);
 
     assert!(
         result.is_ok(),
@@ -33,15 +40,14 @@ fn test_deterministic_state_init_action_view() {
 }
 
 #[test]
-fn test_global_contract_identifier_view_from_crypto_hash() {
-    // CryptoHash is a 32-byte base58 encoded string
-    let json = r#""11111111111111111111111111111111""#;
+fn test_deterministic_state_init_action_view_with_hash() {
+    let json = r#"{"DeterministicStateInit":{"code":{"hash":"AdFXNfTP8JHKhbekQ1XxSetG7qCciL9CnQaCzm373U6R"},"data":{"":"AQ=="},"deposit":"0"}}"#;
 
-    let result: Result<types::GlobalContractIdentifierView, _> = serde_json::from_str(json);
+    let result: Result<types::ActionView, _> = serde_json::from_str(json);
 
     assert!(
         result.is_ok(),
-        "Failed to deserialize GlobalContractIdentifierView from CryptoHash string: {:?}",
+        "Failed to deserialize DeterministicStateInit ActionView with hash: {:?}",
         result.err()
     );
 }

--- a/near-openapi-client/src/lib.rs
+++ b/near-openapi-client/src/lib.rs
@@ -456,6 +456,43 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 impl Client {
+    #[doc = "Calls a view function on a contract and returns the result.\n\nSends a `POST` request to `/EXPERIMENTAL_call_function`\n\n"]
+    pub async fn experimental_call_function<'a>(
+        &'a self,
+        body: &'a types::JsonRpcRequestForExperimentalCallFunction,
+    ) -> Result<
+        ResponseValue<types::JsonRpcResponseForRpcCallFunctionResponseAndRpcCallFunctionError>,
+        Error<()>,
+    > {
+        let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+        );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "experimental_call_function",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
     #[doc = "[Deprecated] Returns changes for a given account, contract or contract code for given block height or hash. Consider using changes instead.\n\nSends a `POST` request to `/EXPERIMENTAL_changes`\n\n"]
     pub async fn experimental_changes<'a>(
         &'a self,
@@ -889,6 +926,267 @@ impl Client {
             .build()?;
         let info = OperationInfo {
             operation_id: "experimental_validators_ordered",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    #[doc = "Returns information about a single access key for given account.\n\nSends a `POST` request to `/EXPERIMENTAL_view_access_key`\n\n"]
+    pub async fn experimental_view_access_key<'a>(
+        &'a self,
+        body: &'a types::JsonRpcRequestForExperimentalViewAccessKey,
+    ) -> Result<
+        ResponseValue<types::JsonRpcResponseForRpcViewAccessKeyResponseAndRpcViewAccessKeyError>,
+        Error<()>,
+    > {
+        let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+        );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "experimental_view_access_key",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    #[doc = "Returns all access keys for a given account.\n\nSends a `POST` request to `/EXPERIMENTAL_view_access_key_list`\n\n"]
+    pub async fn experimental_view_access_key_list<'a>(
+        &'a self,
+        body: &'a types::JsonRpcRequestForExperimentalViewAccessKeyList,
+    ) -> Result<
+        ResponseValue<
+            types::JsonRpcResponseForRpcViewAccessKeyListResponseAndRpcViewAccessKeyListError,
+        >,
+        Error<()>,
+    > {
+        let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+        );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "experimental_view_access_key_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    #[doc = "Returns information about an account for given account_id.\n\nSends a `POST` request to `/EXPERIMENTAL_view_account`\n\n"]
+    pub async fn experimental_view_account<'a>(
+        &'a self,
+        body: &'a types::JsonRpcRequestForExperimentalViewAccount,
+    ) -> Result<
+        ResponseValue<types::JsonRpcResponseForRpcViewAccountResponseAndRpcViewAccountError>,
+        Error<()>,
+    > {
+        let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+        );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "experimental_view_account",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    #[doc = "Returns the contract code (Wasm binary) deployed to the account.\n\nSends a `POST` request to `/EXPERIMENTAL_view_code`\n\n"]
+    pub async fn experimental_view_code<'a>(
+        &'a self,
+        body: &'a types::JsonRpcRequestForExperimentalViewCode,
+    ) -> Result<
+        ResponseValue<types::JsonRpcResponseForRpcViewCodeResponseAndRpcViewCodeError>,
+        Error<()>,
+    > {
+        let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+        );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "experimental_view_code",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    #[doc = "Returns information about a single gas key for given account.\n\nSends a `POST` request to `/EXPERIMENTAL_view_gas_key`\n\n"]
+    pub async fn experimental_view_gas_key<'a>(
+        &'a self,
+        body: &'a types::JsonRpcRequestForExperimentalViewGasKey,
+    ) -> Result<
+        ResponseValue<types::JsonRpcResponseForRpcViewGasKeyResponseAndRpcViewGasKeyError>,
+        Error<()>,
+    > {
+        let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+        );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "experimental_view_gas_key",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    #[doc = "Returns all gas keys for a given account.\n\nSends a `POST` request to `/EXPERIMENTAL_view_gas_key_list`\n\n"]
+    pub async fn experimental_view_gas_key_list<'a>(
+        &'a self,
+        body: &'a types::JsonRpcRequestForExperimentalViewGasKeyList,
+    ) -> Result<
+        ResponseValue<types::JsonRpcResponseForRpcViewGasKeyListResponseAndRpcViewGasKeyListError>,
+        Error<()>,
+    > {
+        let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+        );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "experimental_view_gas_key_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    #[doc = "Returns the state (key-value pairs) of a contract based on the key prefix.\n\nSends a `POST` request to `/EXPERIMENTAL_view_state`\n\n"]
+    pub async fn experimental_view_state<'a>(
+        &'a self,
+        body: &'a types::JsonRpcRequestForExperimentalViewState,
+    ) -> Result<
+        ResponseValue<types::JsonRpcResponseForRpcViewStateResponseAndRpcViewStateError>,
+        Error<()>,
+    > {
+        let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+        );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "experimental_view_state",
         };
         self.pre(&mut request, &info).await?;
         let result = self.exec(request, &info).await;

--- a/near-openapi-client/src/lib.rs
+++ b/near-openapi-client/src/lib.rs
@@ -20,7 +20,7 @@
 
 //!Add near-openapi-client to your project dependencies:
 
-//!```
+//!```sh
 
 //!cargo add near-openapi-client
 
@@ -30,17 +30,19 @@
 
 //!Use the client to get latest block info:
 
-//!```rust
+//!```rust,no_run
 
 //!use near_openapi_client as client;
 
 //!
 
+//!# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+
 //!// Setup client
 
 //!const NEAR_RPC_URL_REMOTE: &str = "https://archival-rpc.mainnet.near.org";
 
-//!let client_remote = client::Client::new(NEAR_RPC_URL_LOCAL);
+//!let client_remote = client::Client::new(NEAR_RPC_URL_REMOTE);
 
 //!
 
@@ -62,11 +64,15 @@
 
 //!// Make the request, get the response
 
-//!let block_final: client::types::JsonRpcResponseForRpcBlockResponseAndRpcError =
+//!let block_final: client::types::JsonRpcResponseForRpcBlockResponseAndRpcBlockError =
 
-//!    client_local.block(&payload_block_final).await?.into_inner();
+//!    client_remote.block(&payload_block_final).await?.into_inner();
 
 //!println!("block_final: {:#?}", block_final);
+
+//!# Ok(())
+
+//!# }
 
 //!```
 
@@ -80,7 +86,7 @@
 
 //!
 
-//!```
+//!```text
 
 //!response for block_final: Variant0 {
 

--- a/near-openapi-types/src/lib.rs
+++ b/near-openapi-types/src/lib.rs
@@ -6707,6 +6707,108 @@ impl ::std::convert::From<InternalError> for ErrorWrapperForRpcBlockError {
         Self::InternalError(value)
     }
 }
+#[doc = "`ErrorWrapperForRpcCallFunctionError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcRequestValidationErrorKind\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"REQUEST_VALIDATION_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcCallFunctionError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"HANDLER_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/InternalError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "cause")]
+pub enum ErrorWrapperForRpcCallFunctionError {
+    #[serde(rename = "REQUEST_VALIDATION_ERROR")]
+    RequestValidationError(RpcRequestValidationErrorKind),
+    #[serde(rename = "HANDLER_ERROR")]
+    HandlerError(RpcCallFunctionError),
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError(InternalError),
+}
+impl ::std::convert::From<&Self> for ErrorWrapperForRpcCallFunctionError {
+    fn from(value: &ErrorWrapperForRpcCallFunctionError) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<RpcRequestValidationErrorKind> for ErrorWrapperForRpcCallFunctionError {
+    fn from(value: RpcRequestValidationErrorKind) -> Self {
+        Self::RequestValidationError(value)
+    }
+}
+impl ::std::convert::From<RpcCallFunctionError> for ErrorWrapperForRpcCallFunctionError {
+    fn from(value: RpcCallFunctionError) -> Self {
+        Self::HandlerError(value)
+    }
+}
+impl ::std::convert::From<InternalError> for ErrorWrapperForRpcCallFunctionError {
+    fn from(value: InternalError) -> Self {
+        Self::InternalError(value)
+    }
+}
 #[doc = "`ErrorWrapperForRpcChunkError`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -8245,6 +8347,722 @@ impl ::std::convert::From<RpcValidatorError> for ErrorWrapperForRpcValidatorErro
     }
 }
 impl ::std::convert::From<InternalError> for ErrorWrapperForRpcValidatorError {
+    fn from(value: InternalError) -> Self {
+        Self::InternalError(value)
+    }
+}
+#[doc = "`ErrorWrapperForRpcViewAccessKeyError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcRequestValidationErrorKind\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"REQUEST_VALIDATION_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewAccessKeyError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"HANDLER_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/InternalError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "cause")]
+pub enum ErrorWrapperForRpcViewAccessKeyError {
+    #[serde(rename = "REQUEST_VALIDATION_ERROR")]
+    RequestValidationError(RpcRequestValidationErrorKind),
+    #[serde(rename = "HANDLER_ERROR")]
+    HandlerError(RpcViewAccessKeyError),
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError(InternalError),
+}
+impl ::std::convert::From<&Self> for ErrorWrapperForRpcViewAccessKeyError {
+    fn from(value: &ErrorWrapperForRpcViewAccessKeyError) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<RpcRequestValidationErrorKind> for ErrorWrapperForRpcViewAccessKeyError {
+    fn from(value: RpcRequestValidationErrorKind) -> Self {
+        Self::RequestValidationError(value)
+    }
+}
+impl ::std::convert::From<RpcViewAccessKeyError> for ErrorWrapperForRpcViewAccessKeyError {
+    fn from(value: RpcViewAccessKeyError) -> Self {
+        Self::HandlerError(value)
+    }
+}
+impl ::std::convert::From<InternalError> for ErrorWrapperForRpcViewAccessKeyError {
+    fn from(value: InternalError) -> Self {
+        Self::InternalError(value)
+    }
+}
+#[doc = "`ErrorWrapperForRpcViewAccessKeyListError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcRequestValidationErrorKind\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"REQUEST_VALIDATION_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewAccessKeyListError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"HANDLER_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/InternalError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "cause")]
+pub enum ErrorWrapperForRpcViewAccessKeyListError {
+    #[serde(rename = "REQUEST_VALIDATION_ERROR")]
+    RequestValidationError(RpcRequestValidationErrorKind),
+    #[serde(rename = "HANDLER_ERROR")]
+    HandlerError(RpcViewAccessKeyListError),
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError(InternalError),
+}
+impl ::std::convert::From<&Self> for ErrorWrapperForRpcViewAccessKeyListError {
+    fn from(value: &ErrorWrapperForRpcViewAccessKeyListError) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<RpcRequestValidationErrorKind>
+    for ErrorWrapperForRpcViewAccessKeyListError
+{
+    fn from(value: RpcRequestValidationErrorKind) -> Self {
+        Self::RequestValidationError(value)
+    }
+}
+impl ::std::convert::From<RpcViewAccessKeyListError> for ErrorWrapperForRpcViewAccessKeyListError {
+    fn from(value: RpcViewAccessKeyListError) -> Self {
+        Self::HandlerError(value)
+    }
+}
+impl ::std::convert::From<InternalError> for ErrorWrapperForRpcViewAccessKeyListError {
+    fn from(value: InternalError) -> Self {
+        Self::InternalError(value)
+    }
+}
+#[doc = "`ErrorWrapperForRpcViewAccountError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcRequestValidationErrorKind\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"REQUEST_VALIDATION_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewAccountError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"HANDLER_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/InternalError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "cause")]
+pub enum ErrorWrapperForRpcViewAccountError {
+    #[serde(rename = "REQUEST_VALIDATION_ERROR")]
+    RequestValidationError(RpcRequestValidationErrorKind),
+    #[serde(rename = "HANDLER_ERROR")]
+    HandlerError(RpcViewAccountError),
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError(InternalError),
+}
+impl ::std::convert::From<&Self> for ErrorWrapperForRpcViewAccountError {
+    fn from(value: &ErrorWrapperForRpcViewAccountError) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<RpcRequestValidationErrorKind> for ErrorWrapperForRpcViewAccountError {
+    fn from(value: RpcRequestValidationErrorKind) -> Self {
+        Self::RequestValidationError(value)
+    }
+}
+impl ::std::convert::From<RpcViewAccountError> for ErrorWrapperForRpcViewAccountError {
+    fn from(value: RpcViewAccountError) -> Self {
+        Self::HandlerError(value)
+    }
+}
+impl ::std::convert::From<InternalError> for ErrorWrapperForRpcViewAccountError {
+    fn from(value: InternalError) -> Self {
+        Self::InternalError(value)
+    }
+}
+#[doc = "`ErrorWrapperForRpcViewCodeError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcRequestValidationErrorKind\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"REQUEST_VALIDATION_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewCodeError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"HANDLER_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/InternalError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "cause")]
+pub enum ErrorWrapperForRpcViewCodeError {
+    #[serde(rename = "REQUEST_VALIDATION_ERROR")]
+    RequestValidationError(RpcRequestValidationErrorKind),
+    #[serde(rename = "HANDLER_ERROR")]
+    HandlerError(RpcViewCodeError),
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError(InternalError),
+}
+impl ::std::convert::From<&Self> for ErrorWrapperForRpcViewCodeError {
+    fn from(value: &ErrorWrapperForRpcViewCodeError) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<RpcRequestValidationErrorKind> for ErrorWrapperForRpcViewCodeError {
+    fn from(value: RpcRequestValidationErrorKind) -> Self {
+        Self::RequestValidationError(value)
+    }
+}
+impl ::std::convert::From<RpcViewCodeError> for ErrorWrapperForRpcViewCodeError {
+    fn from(value: RpcViewCodeError) -> Self {
+        Self::HandlerError(value)
+    }
+}
+impl ::std::convert::From<InternalError> for ErrorWrapperForRpcViewCodeError {
+    fn from(value: InternalError) -> Self {
+        Self::InternalError(value)
+    }
+}
+#[doc = "`ErrorWrapperForRpcViewGasKeyError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcRequestValidationErrorKind\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"REQUEST_VALIDATION_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewGasKeyError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"HANDLER_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/InternalError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "cause")]
+pub enum ErrorWrapperForRpcViewGasKeyError {
+    #[serde(rename = "REQUEST_VALIDATION_ERROR")]
+    RequestValidationError(RpcRequestValidationErrorKind),
+    #[serde(rename = "HANDLER_ERROR")]
+    HandlerError(RpcViewGasKeyError),
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError(InternalError),
+}
+impl ::std::convert::From<&Self> for ErrorWrapperForRpcViewGasKeyError {
+    fn from(value: &ErrorWrapperForRpcViewGasKeyError) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<RpcRequestValidationErrorKind> for ErrorWrapperForRpcViewGasKeyError {
+    fn from(value: RpcRequestValidationErrorKind) -> Self {
+        Self::RequestValidationError(value)
+    }
+}
+impl ::std::convert::From<RpcViewGasKeyError> for ErrorWrapperForRpcViewGasKeyError {
+    fn from(value: RpcViewGasKeyError) -> Self {
+        Self::HandlerError(value)
+    }
+}
+impl ::std::convert::From<InternalError> for ErrorWrapperForRpcViewGasKeyError {
+    fn from(value: InternalError) -> Self {
+        Self::InternalError(value)
+    }
+}
+#[doc = "`ErrorWrapperForRpcViewGasKeyListError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcRequestValidationErrorKind\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"REQUEST_VALIDATION_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewGasKeyListError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"HANDLER_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/InternalError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "cause")]
+pub enum ErrorWrapperForRpcViewGasKeyListError {
+    #[serde(rename = "REQUEST_VALIDATION_ERROR")]
+    RequestValidationError(RpcRequestValidationErrorKind),
+    #[serde(rename = "HANDLER_ERROR")]
+    HandlerError(RpcViewGasKeyListError),
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError(InternalError),
+}
+impl ::std::convert::From<&Self> for ErrorWrapperForRpcViewGasKeyListError {
+    fn from(value: &ErrorWrapperForRpcViewGasKeyListError) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<RpcRequestValidationErrorKind> for ErrorWrapperForRpcViewGasKeyListError {
+    fn from(value: RpcRequestValidationErrorKind) -> Self {
+        Self::RequestValidationError(value)
+    }
+}
+impl ::std::convert::From<RpcViewGasKeyListError> for ErrorWrapperForRpcViewGasKeyListError {
+    fn from(value: RpcViewGasKeyListError) -> Self {
+        Self::HandlerError(value)
+    }
+}
+impl ::std::convert::From<InternalError> for ErrorWrapperForRpcViewGasKeyListError {
+    fn from(value: InternalError) -> Self {
+        Self::InternalError(value)
+    }
+}
+#[doc = "`ErrorWrapperForRpcViewStateError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcRequestValidationErrorKind\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"REQUEST_VALIDATION_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewStateError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"HANDLER_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"cause\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"cause\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/InternalError\""]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "cause")]
+pub enum ErrorWrapperForRpcViewStateError {
+    #[serde(rename = "REQUEST_VALIDATION_ERROR")]
+    RequestValidationError(RpcRequestValidationErrorKind),
+    #[serde(rename = "HANDLER_ERROR")]
+    HandlerError(RpcViewStateError),
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError(InternalError),
+}
+impl ::std::convert::From<&Self> for ErrorWrapperForRpcViewStateError {
+    fn from(value: &ErrorWrapperForRpcViewStateError) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<RpcRequestValidationErrorKind> for ErrorWrapperForRpcViewStateError {
+    fn from(value: RpcRequestValidationErrorKind) -> Self {
+        Self::RequestValidationError(value)
+    }
+}
+impl ::std::convert::From<RpcViewStateError> for ErrorWrapperForRpcViewStateError {
+    fn from(value: RpcViewStateError) -> Self {
+        Self::HandlerError(value)
+    }
+}
+impl ::std::convert::From<InternalError> for ErrorWrapperForRpcViewStateError {
     fn from(value: InternalError) -> Self {
         Self::InternalError(value)
     }
@@ -11215,19 +12033,38 @@ impl ::std::convert::From<AccountId> for GlobalContractIdentifier {
 #[doc = "{"]
 #[doc = "  \"oneOf\": ["]
 #[doc = "    {"]
-#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"hash\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"hash\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "        }"]
+#[doc = "      },"]
+#[doc = "      \"additionalProperties\": false"]
 #[doc = "    },"]
 #[doc = "    {"]
-#[doc = "      \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"account_id\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"account_id\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "        }"]
+#[doc = "      },"]
+#[doc = "      \"additionalProperties\": false"]
 #[doc = "    }"]
 #[doc = "  ]"]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
 pub enum GlobalContractIdentifierView {
-    CryptoHash(CryptoHash),
+    #[serde(rename = "hash")]
+    Hash(CryptoHash),
+    #[serde(rename = "account_id")]
     AccountId(AccountId),
 }
 impl ::std::convert::From<&Self> for GlobalContractIdentifierView {
@@ -11235,17 +12072,9 @@ impl ::std::convert::From<&Self> for GlobalContractIdentifierView {
         value.clone()
     }
 }
-impl ::std::fmt::Display for GlobalContractIdentifierView {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::CryptoHash(x) => x.fmt(f),
-            Self::AccountId(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<CryptoHash> for GlobalContractIdentifierView {
     fn from(value: CryptoHash) -> Self {
-        Self::CryptoHash(value)
+        Self::Hash(value)
     }
 }
 impl ::std::convert::From<AccountId> for GlobalContractIdentifierView {
@@ -13444,6 +14273,130 @@ impl ::std::convert::TryFrom<::std::string::String> for JsonRpcRequestForClientC
         value.parse()
     }
 }
+#[doc = "`JsonRpcRequestForExperimentalCallFunction`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcRequest_for_EXPERIMENTAL_call_function\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\","]
+#[doc = "    \"method\","]
+#[doc = "    \"params\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"method\": {"]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"EXPERIMENTAL_call_function\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"params\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/RpcCallFunctionRequest\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct JsonRpcRequestForExperimentalCallFunction {
+    pub id: ::std::string::String,
+    pub jsonrpc: ::std::string::String,
+    pub method: JsonRpcRequestForExperimentalCallFunctionMethod,
+    pub params: RpcCallFunctionRequest,
+}
+impl ::std::convert::From<&JsonRpcRequestForExperimentalCallFunction>
+    for JsonRpcRequestForExperimentalCallFunction
+{
+    fn from(value: &JsonRpcRequestForExperimentalCallFunction) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalCallFunctionMethod`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"EXPERIMENTAL_call_function\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum JsonRpcRequestForExperimentalCallFunctionMethod {
+    #[serde(rename = "EXPERIMENTAL_call_function")]
+    ExperimentalCallFunction,
+}
+impl ::std::convert::From<&Self> for JsonRpcRequestForExperimentalCallFunctionMethod {
+    fn from(value: &JsonRpcRequestForExperimentalCallFunctionMethod) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for JsonRpcRequestForExperimentalCallFunctionMethod {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::ExperimentalCallFunction => f.write_str("EXPERIMENTAL_call_function"),
+        }
+    }
+}
+impl ::std::str::FromStr for JsonRpcRequestForExperimentalCallFunctionMethod {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "EXPERIMENTAL_call_function" => Ok(Self::ExperimentalCallFunction),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for JsonRpcRequestForExperimentalCallFunctionMethod {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String>
+    for JsonRpcRequestForExperimentalCallFunctionMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String>
+    for JsonRpcRequestForExperimentalCallFunctionMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
 #[doc = "`JsonRpcRequestForExperimentalChanges`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -14922,6 +15875,874 @@ impl ::std::convert::TryFrom<&::std::string::String>
 }
 impl ::std::convert::TryFrom<::std::string::String>
     for JsonRpcRequestForExperimentalValidatorsOrderedMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewAccessKey`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcRequest_for_EXPERIMENTAL_view_access_key\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\","]
+#[doc = "    \"method\","]
+#[doc = "    \"params\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"method\": {"]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"EXPERIMENTAL_view_access_key\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"params\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/RpcViewAccessKeyRequest\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct JsonRpcRequestForExperimentalViewAccessKey {
+    pub id: ::std::string::String,
+    pub jsonrpc: ::std::string::String,
+    pub method: JsonRpcRequestForExperimentalViewAccessKeyMethod,
+    pub params: RpcViewAccessKeyRequest,
+}
+impl ::std::convert::From<&JsonRpcRequestForExperimentalViewAccessKey>
+    for JsonRpcRequestForExperimentalViewAccessKey
+{
+    fn from(value: &JsonRpcRequestForExperimentalViewAccessKey) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewAccessKeyList`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcRequest_for_EXPERIMENTAL_view_access_key_list\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\","]
+#[doc = "    \"method\","]
+#[doc = "    \"params\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"method\": {"]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"EXPERIMENTAL_view_access_key_list\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"params\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/RpcViewAccessKeyListRequest\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct JsonRpcRequestForExperimentalViewAccessKeyList {
+    pub id: ::std::string::String,
+    pub jsonrpc: ::std::string::String,
+    pub method: JsonRpcRequestForExperimentalViewAccessKeyListMethod,
+    pub params: RpcViewAccessKeyListRequest,
+}
+impl ::std::convert::From<&JsonRpcRequestForExperimentalViewAccessKeyList>
+    for JsonRpcRequestForExperimentalViewAccessKeyList
+{
+    fn from(value: &JsonRpcRequestForExperimentalViewAccessKeyList) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewAccessKeyListMethod`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"EXPERIMENTAL_view_access_key_list\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum JsonRpcRequestForExperimentalViewAccessKeyListMethod {
+    #[serde(rename = "EXPERIMENTAL_view_access_key_list")]
+    ExperimentalViewAccessKeyList,
+}
+impl ::std::convert::From<&Self> for JsonRpcRequestForExperimentalViewAccessKeyListMethod {
+    fn from(value: &JsonRpcRequestForExperimentalViewAccessKeyListMethod) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for JsonRpcRequestForExperimentalViewAccessKeyListMethod {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::ExperimentalViewAccessKeyList => f.write_str("EXPERIMENTAL_view_access_key_list"),
+        }
+    }
+}
+impl ::std::str::FromStr for JsonRpcRequestForExperimentalViewAccessKeyListMethod {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "EXPERIMENTAL_view_access_key_list" => Ok(Self::ExperimentalViewAccessKeyList),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for JsonRpcRequestForExperimentalViewAccessKeyListMethod {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String>
+    for JsonRpcRequestForExperimentalViewAccessKeyListMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String>
+    for JsonRpcRequestForExperimentalViewAccessKeyListMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewAccessKeyMethod`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"EXPERIMENTAL_view_access_key\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum JsonRpcRequestForExperimentalViewAccessKeyMethod {
+    #[serde(rename = "EXPERIMENTAL_view_access_key")]
+    ExperimentalViewAccessKey,
+}
+impl ::std::convert::From<&Self> for JsonRpcRequestForExperimentalViewAccessKeyMethod {
+    fn from(value: &JsonRpcRequestForExperimentalViewAccessKeyMethod) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for JsonRpcRequestForExperimentalViewAccessKeyMethod {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::ExperimentalViewAccessKey => f.write_str("EXPERIMENTAL_view_access_key"),
+        }
+    }
+}
+impl ::std::str::FromStr for JsonRpcRequestForExperimentalViewAccessKeyMethod {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "EXPERIMENTAL_view_access_key" => Ok(Self::ExperimentalViewAccessKey),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for JsonRpcRequestForExperimentalViewAccessKeyMethod {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String>
+    for JsonRpcRequestForExperimentalViewAccessKeyMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String>
+    for JsonRpcRequestForExperimentalViewAccessKeyMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewAccount`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcRequest_for_EXPERIMENTAL_view_account\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\","]
+#[doc = "    \"method\","]
+#[doc = "    \"params\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"method\": {"]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"EXPERIMENTAL_view_account\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"params\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/RpcViewAccountRequest\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct JsonRpcRequestForExperimentalViewAccount {
+    pub id: ::std::string::String,
+    pub jsonrpc: ::std::string::String,
+    pub method: JsonRpcRequestForExperimentalViewAccountMethod,
+    pub params: RpcViewAccountRequest,
+}
+impl ::std::convert::From<&JsonRpcRequestForExperimentalViewAccount>
+    for JsonRpcRequestForExperimentalViewAccount
+{
+    fn from(value: &JsonRpcRequestForExperimentalViewAccount) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewAccountMethod`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"EXPERIMENTAL_view_account\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum JsonRpcRequestForExperimentalViewAccountMethod {
+    #[serde(rename = "EXPERIMENTAL_view_account")]
+    ExperimentalViewAccount,
+}
+impl ::std::convert::From<&Self> for JsonRpcRequestForExperimentalViewAccountMethod {
+    fn from(value: &JsonRpcRequestForExperimentalViewAccountMethod) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for JsonRpcRequestForExperimentalViewAccountMethod {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::ExperimentalViewAccount => f.write_str("EXPERIMENTAL_view_account"),
+        }
+    }
+}
+impl ::std::str::FromStr for JsonRpcRequestForExperimentalViewAccountMethod {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "EXPERIMENTAL_view_account" => Ok(Self::ExperimentalViewAccount),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for JsonRpcRequestForExperimentalViewAccountMethod {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String>
+    for JsonRpcRequestForExperimentalViewAccountMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String>
+    for JsonRpcRequestForExperimentalViewAccountMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewCode`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcRequest_for_EXPERIMENTAL_view_code\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\","]
+#[doc = "    \"method\","]
+#[doc = "    \"params\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"method\": {"]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"EXPERIMENTAL_view_code\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"params\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/RpcViewCodeRequest\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct JsonRpcRequestForExperimentalViewCode {
+    pub id: ::std::string::String,
+    pub jsonrpc: ::std::string::String,
+    pub method: JsonRpcRequestForExperimentalViewCodeMethod,
+    pub params: RpcViewCodeRequest,
+}
+impl ::std::convert::From<&JsonRpcRequestForExperimentalViewCode>
+    for JsonRpcRequestForExperimentalViewCode
+{
+    fn from(value: &JsonRpcRequestForExperimentalViewCode) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewCodeMethod`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"EXPERIMENTAL_view_code\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum JsonRpcRequestForExperimentalViewCodeMethod {
+    #[serde(rename = "EXPERIMENTAL_view_code")]
+    ExperimentalViewCode,
+}
+impl ::std::convert::From<&Self> for JsonRpcRequestForExperimentalViewCodeMethod {
+    fn from(value: &JsonRpcRequestForExperimentalViewCodeMethod) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for JsonRpcRequestForExperimentalViewCodeMethod {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::ExperimentalViewCode => f.write_str("EXPERIMENTAL_view_code"),
+        }
+    }
+}
+impl ::std::str::FromStr for JsonRpcRequestForExperimentalViewCodeMethod {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "EXPERIMENTAL_view_code" => Ok(Self::ExperimentalViewCode),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for JsonRpcRequestForExperimentalViewCodeMethod {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String>
+    for JsonRpcRequestForExperimentalViewCodeMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String>
+    for JsonRpcRequestForExperimentalViewCodeMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewGasKey`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcRequest_for_EXPERIMENTAL_view_gas_key\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\","]
+#[doc = "    \"method\","]
+#[doc = "    \"params\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"method\": {"]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"EXPERIMENTAL_view_gas_key\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"params\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/RpcViewGasKeyRequest\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct JsonRpcRequestForExperimentalViewGasKey {
+    pub id: ::std::string::String,
+    pub jsonrpc: ::std::string::String,
+    pub method: JsonRpcRequestForExperimentalViewGasKeyMethod,
+    pub params: RpcViewGasKeyRequest,
+}
+impl ::std::convert::From<&JsonRpcRequestForExperimentalViewGasKey>
+    for JsonRpcRequestForExperimentalViewGasKey
+{
+    fn from(value: &JsonRpcRequestForExperimentalViewGasKey) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewGasKeyList`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcRequest_for_EXPERIMENTAL_view_gas_key_list\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\","]
+#[doc = "    \"method\","]
+#[doc = "    \"params\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"method\": {"]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"EXPERIMENTAL_view_gas_key_list\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"params\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/RpcViewGasKeyListRequest\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct JsonRpcRequestForExperimentalViewGasKeyList {
+    pub id: ::std::string::String,
+    pub jsonrpc: ::std::string::String,
+    pub method: JsonRpcRequestForExperimentalViewGasKeyListMethod,
+    pub params: RpcViewGasKeyListRequest,
+}
+impl ::std::convert::From<&JsonRpcRequestForExperimentalViewGasKeyList>
+    for JsonRpcRequestForExperimentalViewGasKeyList
+{
+    fn from(value: &JsonRpcRequestForExperimentalViewGasKeyList) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewGasKeyListMethod`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"EXPERIMENTAL_view_gas_key_list\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum JsonRpcRequestForExperimentalViewGasKeyListMethod {
+    #[serde(rename = "EXPERIMENTAL_view_gas_key_list")]
+    ExperimentalViewGasKeyList,
+}
+impl ::std::convert::From<&Self> for JsonRpcRequestForExperimentalViewGasKeyListMethod {
+    fn from(value: &JsonRpcRequestForExperimentalViewGasKeyListMethod) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for JsonRpcRequestForExperimentalViewGasKeyListMethod {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::ExperimentalViewGasKeyList => f.write_str("EXPERIMENTAL_view_gas_key_list"),
+        }
+    }
+}
+impl ::std::str::FromStr for JsonRpcRequestForExperimentalViewGasKeyListMethod {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "EXPERIMENTAL_view_gas_key_list" => Ok(Self::ExperimentalViewGasKeyList),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for JsonRpcRequestForExperimentalViewGasKeyListMethod {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String>
+    for JsonRpcRequestForExperimentalViewGasKeyListMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String>
+    for JsonRpcRequestForExperimentalViewGasKeyListMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewGasKeyMethod`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"EXPERIMENTAL_view_gas_key\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum JsonRpcRequestForExperimentalViewGasKeyMethod {
+    #[serde(rename = "EXPERIMENTAL_view_gas_key")]
+    ExperimentalViewGasKey,
+}
+impl ::std::convert::From<&Self> for JsonRpcRequestForExperimentalViewGasKeyMethod {
+    fn from(value: &JsonRpcRequestForExperimentalViewGasKeyMethod) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for JsonRpcRequestForExperimentalViewGasKeyMethod {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::ExperimentalViewGasKey => f.write_str("EXPERIMENTAL_view_gas_key"),
+        }
+    }
+}
+impl ::std::str::FromStr for JsonRpcRequestForExperimentalViewGasKeyMethod {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "EXPERIMENTAL_view_gas_key" => Ok(Self::ExperimentalViewGasKey),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for JsonRpcRequestForExperimentalViewGasKeyMethod {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String>
+    for JsonRpcRequestForExperimentalViewGasKeyMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String>
+    for JsonRpcRequestForExperimentalViewGasKeyMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewState`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcRequest_for_EXPERIMENTAL_view_state\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\","]
+#[doc = "    \"method\","]
+#[doc = "    \"params\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"method\": {"]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"EXPERIMENTAL_view_state\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"params\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/RpcViewStateRequest\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct JsonRpcRequestForExperimentalViewState {
+    pub id: ::std::string::String,
+    pub jsonrpc: ::std::string::String,
+    pub method: JsonRpcRequestForExperimentalViewStateMethod,
+    pub params: RpcViewStateRequest,
+}
+impl ::std::convert::From<&JsonRpcRequestForExperimentalViewState>
+    for JsonRpcRequestForExperimentalViewState
+{
+    fn from(value: &JsonRpcRequestForExperimentalViewState) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcRequestForExperimentalViewStateMethod`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"EXPERIMENTAL_view_state\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum JsonRpcRequestForExperimentalViewStateMethod {
+    #[serde(rename = "EXPERIMENTAL_view_state")]
+    ExperimentalViewState,
+}
+impl ::std::convert::From<&Self> for JsonRpcRequestForExperimentalViewStateMethod {
+    fn from(value: &JsonRpcRequestForExperimentalViewStateMethod) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for JsonRpcRequestForExperimentalViewStateMethod {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::ExperimentalViewState => f.write_str("EXPERIMENTAL_view_state"),
+        }
+    }
+}
+impl ::std::str::FromStr for JsonRpcRequestForExperimentalViewStateMethod {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "EXPERIMENTAL_view_state" => Ok(Self::ExperimentalViewState),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for JsonRpcRequestForExperimentalViewStateMethod {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String>
+    for JsonRpcRequestForExperimentalViewStateMethod
+{
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String>
+    for JsonRpcRequestForExperimentalViewStateMethod
 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -16769,6 +18590,74 @@ impl ::std::convert::From<&Self> for JsonRpcResponseForRpcBlockResponseAndRpcBlo
         value.clone()
     }
 }
+#[doc = "`JsonRpcResponseForRpcCallFunctionResponseAndRpcCallFunctionError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcResponse_for_RpcCallFunctionResponse_and_RpcCallFunctionError\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"result\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"result\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcCallFunctionResponse\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"error\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"error\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/ErrorWrapper_for_RpcCallFunctionError\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum JsonRpcResponseForRpcCallFunctionResponseAndRpcCallFunctionError {
+    Variant0 {
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+        result: RpcCallFunctionResponse,
+    },
+    Variant1 {
+        error: ErrorWrapperForRpcCallFunctionError,
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self>
+    for JsonRpcResponseForRpcCallFunctionResponseAndRpcCallFunctionError
+{
+    fn from(value: &JsonRpcResponseForRpcCallFunctionResponseAndRpcCallFunctionError) -> Self {
+        value.clone()
+    }
+}
 #[doc = "`JsonRpcResponseForRpcChunkResponseAndRpcChunkError`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -17920,6 +19809,478 @@ pub enum JsonRpcResponseForRpcValidatorResponseAndRpcValidatorError {
 }
 impl ::std::convert::From<&Self> for JsonRpcResponseForRpcValidatorResponseAndRpcValidatorError {
     fn from(value: &JsonRpcResponseForRpcValidatorResponseAndRpcValidatorError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcResponseForRpcViewAccessKeyListResponseAndRpcViewAccessKeyListError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcResponse_for_RpcViewAccessKeyListResponse_and_RpcViewAccessKeyListError\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"result\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"result\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewAccessKeyListResponse\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"error\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"error\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/ErrorWrapper_for_RpcViewAccessKeyListError\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum JsonRpcResponseForRpcViewAccessKeyListResponseAndRpcViewAccessKeyListError {
+    Variant0 {
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+        result: RpcViewAccessKeyListResponse,
+    },
+    Variant1 {
+        error: ErrorWrapperForRpcViewAccessKeyListError,
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self>
+    for JsonRpcResponseForRpcViewAccessKeyListResponseAndRpcViewAccessKeyListError
+{
+    fn from(
+        value: &JsonRpcResponseForRpcViewAccessKeyListResponseAndRpcViewAccessKeyListError,
+    ) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcResponseForRpcViewAccessKeyResponseAndRpcViewAccessKeyError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcResponse_for_RpcViewAccessKeyResponse_and_RpcViewAccessKeyError\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"result\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"result\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewAccessKeyResponse\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"error\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"error\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/ErrorWrapper_for_RpcViewAccessKeyError\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum JsonRpcResponseForRpcViewAccessKeyResponseAndRpcViewAccessKeyError {
+    Variant0 {
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+        result: RpcViewAccessKeyResponse,
+    },
+    Variant1 {
+        error: ErrorWrapperForRpcViewAccessKeyError,
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self>
+    for JsonRpcResponseForRpcViewAccessKeyResponseAndRpcViewAccessKeyError
+{
+    fn from(value: &JsonRpcResponseForRpcViewAccessKeyResponseAndRpcViewAccessKeyError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcResponseForRpcViewAccountResponseAndRpcViewAccountError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcResponse_for_RpcViewAccountResponse_and_RpcViewAccountError\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"result\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"result\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewAccountResponse\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"error\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"error\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/ErrorWrapper_for_RpcViewAccountError\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum JsonRpcResponseForRpcViewAccountResponseAndRpcViewAccountError {
+    Variant0 {
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+        result: RpcViewAccountResponse,
+    },
+    Variant1 {
+        error: ErrorWrapperForRpcViewAccountError,
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self>
+    for JsonRpcResponseForRpcViewAccountResponseAndRpcViewAccountError
+{
+    fn from(value: &JsonRpcResponseForRpcViewAccountResponseAndRpcViewAccountError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcResponseForRpcViewCodeResponseAndRpcViewCodeError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcResponse_for_RpcViewCodeResponse_and_RpcViewCodeError\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"result\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"result\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewCodeResponse\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"error\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"error\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/ErrorWrapper_for_RpcViewCodeError\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum JsonRpcResponseForRpcViewCodeResponseAndRpcViewCodeError {
+    Variant0 {
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+        result: RpcViewCodeResponse,
+    },
+    Variant1 {
+        error: ErrorWrapperForRpcViewCodeError,
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for JsonRpcResponseForRpcViewCodeResponseAndRpcViewCodeError {
+    fn from(value: &JsonRpcResponseForRpcViewCodeResponseAndRpcViewCodeError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcResponseForRpcViewGasKeyListResponseAndRpcViewGasKeyListError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcResponse_for_RpcViewGasKeyListResponse_and_RpcViewGasKeyListError\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"result\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"result\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewGasKeyListResponse\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"error\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"error\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/ErrorWrapper_for_RpcViewGasKeyListError\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum JsonRpcResponseForRpcViewGasKeyListResponseAndRpcViewGasKeyListError {
+    Variant0 {
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+        result: RpcViewGasKeyListResponse,
+    },
+    Variant1 {
+        error: ErrorWrapperForRpcViewGasKeyListError,
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self>
+    for JsonRpcResponseForRpcViewGasKeyListResponseAndRpcViewGasKeyListError
+{
+    fn from(value: &JsonRpcResponseForRpcViewGasKeyListResponseAndRpcViewGasKeyListError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcResponseForRpcViewGasKeyResponseAndRpcViewGasKeyError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcResponse_for_RpcViewGasKeyResponse_and_RpcViewGasKeyError\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"result\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"result\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewGasKeyResponse\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"error\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"error\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/ErrorWrapper_for_RpcViewGasKeyError\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum JsonRpcResponseForRpcViewGasKeyResponseAndRpcViewGasKeyError {
+    Variant0 {
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+        result: RpcViewGasKeyResponse,
+    },
+    Variant1 {
+        error: ErrorWrapperForRpcViewGasKeyError,
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for JsonRpcResponseForRpcViewGasKeyResponseAndRpcViewGasKeyError {
+    fn from(value: &JsonRpcResponseForRpcViewGasKeyResponseAndRpcViewGasKeyError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`JsonRpcResponseForRpcViewStateResponseAndRpcViewStateError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"JsonRpcResponse_for_RpcViewStateResponse_and_RpcViewStateError\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"result\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"result\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/RpcViewStateResponse\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"error\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"error\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/ErrorWrapper_for_RpcViewStateError\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"id\","]
+#[doc = "    \"jsonrpc\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"id\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"jsonrpc\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum JsonRpcResponseForRpcViewStateResponseAndRpcViewStateError {
+    Variant0 {
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+        result: RpcViewStateResponse,
+    },
+    Variant1 {
+        error: ErrorWrapperForRpcViewStateError,
+        id: ::std::string::String,
+        jsonrpc: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for JsonRpcResponseForRpcViewStateResponseAndRpcViewStateError {
+    fn from(value: &JsonRpcResponseForRpcViewStateResponseAndRpcViewStateError) -> Self {
         value.clone()
     }
 }
@@ -20393,6 +22754,402 @@ impl ::std::convert::From<&RpcBlockResponse> for RpcBlockResponse {
         value.clone()
     }
 }
+#[doc = "`RpcCallFunctionError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_reference\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_reference\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/BlockReference\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_BLOCK\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INVALID_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"contract_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"contract_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"NO_CONTRACT_CODE\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"vm_error\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"vm_error\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/FunctionCallError\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"CONTRACT_EXECUTION_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"error_message\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"error_message\": {"]
+#[doc = "              \"type\": \"string\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "info")]
+pub enum RpcCallFunctionError {
+    #[serde(rename = "UNKNOWN_BLOCK")]
+    UnknownBlock { block_reference: BlockReference },
+    #[serde(rename = "INVALID_ACCOUNT")]
+    InvalidAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_ACCOUNT")]
+    UnknownAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "NO_CONTRACT_CODE")]
+    NoContractCode {
+        block_hash: CryptoHash,
+        block_height: u64,
+        contract_account_id: AccountId,
+    },
+    #[serde(rename = "CONTRACT_EXECUTION_ERROR")]
+    ContractExecutionError {
+        block_hash: CryptoHash,
+        block_height: u64,
+        vm_error: FunctionCallError,
+    },
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError {
+        error_message: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for RpcCallFunctionError {
+    fn from(value: &RpcCallFunctionError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcCallFunctionRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"RpcCallFunctionRequest\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"block_id\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"block_id\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/BlockId\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"finality\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"finality\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/Finality\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"sync_checkpoint\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"sync_checkpoint\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/SyncCheckpoint\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"account_id\","]
+#[doc = "    \"args_base64\","]
+#[doc = "    \"method_name\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"account_id\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "    },"]
+#[doc = "    \"args_base64\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/FunctionArgs\""]
+#[doc = "    },"]
+#[doc = "    \"method_name\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum RpcCallFunctionRequest {
+    Variant0 {
+        account_id: AccountId,
+        args_base64: FunctionArgs,
+        block_id: BlockId,
+        method_name: ::std::string::String,
+    },
+    Variant1 {
+        account_id: AccountId,
+        args_base64: FunctionArgs,
+        finality: Finality,
+        method_name: ::std::string::String,
+    },
+    Variant2 {
+        account_id: AccountId,
+        args_base64: FunctionArgs,
+        method_name: ::std::string::String,
+        sync_checkpoint: SyncCheckpoint,
+    },
+}
+impl ::std::convert::From<&Self> for RpcCallFunctionRequest {
+    fn from(value: &RpcCallFunctionRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "A result returned by contract method"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"description\": \"A result returned by contract method\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"block_hash\","]
+#[doc = "    \"block_height\","]
+#[doc = "    \"logs\","]
+#[doc = "    \"result\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"block_hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    },"]
+#[doc = "    \"block_height\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"logs\": {"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    \"result\": {"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"type\": \"integer\","]
+#[doc = "        \"format\": \"uint8\","]
+#[doc = "        \"maximum\": 255.0,"]
+#[doc = "        \"minimum\": 0.0"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct RpcCallFunctionResponse {
+    pub block_hash: CryptoHash,
+    pub block_height: u64,
+    pub logs: ::std::vec::Vec<::std::string::String>,
+    pub result: ::std::vec::Vec<u8>,
+}
+impl ::std::convert::From<&RpcCallFunctionResponse> for RpcCallFunctionResponse {
+    fn from(value: &RpcCallFunctionResponse) -> Self {
+        value.clone()
+    }
+}
 #[doc = "`RpcChunkError`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20857,10 +23614,6 @@ impl ::std::convert::From<()> for RpcClientConfigRequest {
 #[doc = "      \"maxItems\": 2,"]
 #[doc = "      \"minItems\": 2"]
 #[doc = "    },"]
-#[doc = "    \"dynamic_resharding_dry_run\": {"]
-#[doc = "      \"description\": \"If true, the runtime will do a dynamic resharding 'dry run' at the last block of each epoch.\\nThis means calculating tentative boundary accounts for splitting the tracked shards.\","]
-#[doc = "      \"type\": \"boolean\""]
-#[doc = "    },"]
 #[doc = "    \"enable_early_prepare_transactions\": {"]
 #[doc = "      \"description\": \"If true, transactions for the next chunk will be prepared early, right after the previous chunk's\\npost-state is ready. This can help produce chunks faster, for high-throughput chains.\\nThe current implementation increases latency on low-load chains, which will be fixed in the future.\\nThe default is disabled.\","]
 #[doc = "      \"type\": \"boolean\""]
@@ -21303,9 +24056,6 @@ pub struct RpcClientConfigResponse {
     #[doc = "Time between running doomslug timer."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub doomslug_step_period: ::std::option::Option<[u64; 2usize]>,
-    #[doc = "If true, the runtime will do a dynamic resharding 'dry run' at the last block of each epoch.\nThis means calculating tentative boundary accounts for splitting the tracked shards."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub dynamic_resharding_dry_run: ::std::option::Option<bool>,
     #[doc = "If true, transactions for the next chunk will be prepared early, right after the previous chunk's\npost-state is ready. This can help produce chunks faster, for high-throughput chains.\nThe current implementation increases latency on low-load chains, which will be fixed in the future.\nThe default is disabled."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub enable_early_prepare_transactions: ::std::option::Option<bool>,
@@ -21488,7 +24238,6 @@ impl ::std::default::Default for RpcClientConfigResponse {
             cloud_archival_writer: Default::default(),
             disable_tx_routing: Default::default(),
             doomslug_step_period: Default::default(),
-            dynamic_resharding_dry_run: Default::default(),
             enable_early_prepare_transactions: Default::default(),
             enable_multiline_logging: Default::default(),
             enable_statistics_export: Default::default(),
@@ -23875,6 +26624,7 @@ impl ::std::default::Default for RpcProtocolConfigResponse {
 #[doc = "          \"required\": ["]
 #[doc = "            \"block_hash\","]
 #[doc = "            \"block_height\","]
+#[doc = "            \"error\","]
 #[doc = "            \"vm_error\""]
 #[doc = "          ],"]
 #[doc = "          \"properties\": {"]
@@ -23885,6 +26635,9 @@ impl ::std::default::Default for RpcProtocolConfigResponse {
 #[doc = "              \"type\": \"integer\","]
 #[doc = "              \"format\": \"uint64\","]
 #[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"error\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/FunctionCallError\""]
 #[doc = "            },"]
 #[doc = "            \"vm_error\": {"]
 #[doc = "              \"type\": \"string\""]
@@ -24026,6 +26779,7 @@ pub enum RpcQueryError {
     ContractExecutionError {
         block_hash: CryptoHash,
         block_height: u64,
+        error: FunctionCallError,
         vm_error: ::std::string::String,
     },
     #[serde(rename = "NO_GLOBAL_CONTRACT_CODE")]
@@ -28002,6 +30756,2293 @@ impl ::std::default::Default for RpcValidatorsOrderedRequest {
         Self {
             block_id: Default::default(),
         }
+    }
+}
+#[doc = "`RpcViewAccessKeyError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_reference\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_reference\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/BlockReference\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_BLOCK\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INVALID_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"public_key\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"public_key\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/PublicKey\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_ACCESS_KEY\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"error_message\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"error_message\": {"]
+#[doc = "              \"type\": \"string\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "info")]
+pub enum RpcViewAccessKeyError {
+    #[serde(rename = "UNKNOWN_BLOCK")]
+    UnknownBlock { block_reference: BlockReference },
+    #[serde(rename = "INVALID_ACCOUNT")]
+    InvalidAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_ACCOUNT")]
+    UnknownAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_ACCESS_KEY")]
+    UnknownAccessKey {
+        block_hash: CryptoHash,
+        block_height: u64,
+        public_key: PublicKey,
+    },
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError {
+        error_message: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewAccessKeyError {
+    fn from(value: &RpcViewAccessKeyError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewAccessKeyListError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_reference\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_reference\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/BlockReference\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_BLOCK\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INVALID_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"error_message\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"error_message\": {"]
+#[doc = "              \"type\": \"string\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "info")]
+pub enum RpcViewAccessKeyListError {
+    #[serde(rename = "UNKNOWN_BLOCK")]
+    UnknownBlock { block_reference: BlockReference },
+    #[serde(rename = "INVALID_ACCOUNT")]
+    InvalidAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_ACCOUNT")]
+    UnknownAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError {
+        error_message: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewAccessKeyListError {
+    fn from(value: &RpcViewAccessKeyListError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewAccessKeyListRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"RpcViewAccessKeyListRequest\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"block_id\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"block_id\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/BlockId\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"finality\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"finality\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/Finality\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"sync_checkpoint\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"sync_checkpoint\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/SyncCheckpoint\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"account_id\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"account_id\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum RpcViewAccessKeyListRequest {
+    Variant0 {
+        account_id: AccountId,
+        block_id: BlockId,
+    },
+    Variant1 {
+        account_id: AccountId,
+        finality: Finality,
+    },
+    Variant2 {
+        account_id: AccountId,
+        sync_checkpoint: SyncCheckpoint,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewAccessKeyListRequest {
+    fn from(value: &RpcViewAccessKeyListRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "Lists access keys"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"description\": \"Lists access keys\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"block_hash\","]
+#[doc = "    \"block_height\","]
+#[doc = "    \"keys\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"block_hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    },"]
+#[doc = "    \"block_height\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"keys\": {"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"$ref\": \"#/components/schemas/AccessKeyInfoView\""]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct RpcViewAccessKeyListResponse {
+    pub block_hash: CryptoHash,
+    pub block_height: u64,
+    pub keys: ::std::vec::Vec<AccessKeyInfoView>,
+}
+impl ::std::convert::From<&RpcViewAccessKeyListResponse> for RpcViewAccessKeyListResponse {
+    fn from(value: &RpcViewAccessKeyListResponse) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewAccessKeyRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"RpcViewAccessKeyRequest\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"block_id\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"block_id\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/BlockId\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"finality\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"finality\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/Finality\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"sync_checkpoint\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"sync_checkpoint\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/SyncCheckpoint\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"account_id\","]
+#[doc = "    \"public_key\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"account_id\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "    },"]
+#[doc = "    \"public_key\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/PublicKey\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum RpcViewAccessKeyRequest {
+    Variant0 {
+        account_id: AccountId,
+        block_id: BlockId,
+        public_key: PublicKey,
+    },
+    Variant1 {
+        account_id: AccountId,
+        finality: Finality,
+        public_key: PublicKey,
+    },
+    Variant2 {
+        account_id: AccountId,
+        public_key: PublicKey,
+        sync_checkpoint: SyncCheckpoint,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewAccessKeyRequest {
+    fn from(value: &RpcViewAccessKeyRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "Describes access key permission scope and nonce."]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"description\": \"Describes access key permission scope and nonce.\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"block_hash\","]
+#[doc = "    \"block_height\","]
+#[doc = "    \"nonce\","]
+#[doc = "    \"permission\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"block_hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    },"]
+#[doc = "    \"block_height\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"nonce\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"permission\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccessKeyPermissionView\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct RpcViewAccessKeyResponse {
+    pub block_hash: CryptoHash,
+    pub block_height: u64,
+    pub nonce: u64,
+    pub permission: AccessKeyPermissionView,
+}
+impl ::std::convert::From<&RpcViewAccessKeyResponse> for RpcViewAccessKeyResponse {
+    fn from(value: &RpcViewAccessKeyResponse) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewAccountError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_reference\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_reference\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/BlockReference\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_BLOCK\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INVALID_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"error_message\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"error_message\": {"]
+#[doc = "              \"type\": \"string\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "info")]
+pub enum RpcViewAccountError {
+    #[serde(rename = "UNKNOWN_BLOCK")]
+    UnknownBlock { block_reference: BlockReference },
+    #[serde(rename = "INVALID_ACCOUNT")]
+    InvalidAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_ACCOUNT")]
+    UnknownAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError {
+        error_message: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewAccountError {
+    fn from(value: &RpcViewAccountError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewAccountRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"RpcViewAccountRequest\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"block_id\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"block_id\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/BlockId\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"finality\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"finality\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/Finality\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"sync_checkpoint\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"sync_checkpoint\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/SyncCheckpoint\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"account_id\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"account_id\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum RpcViewAccountRequest {
+    Variant0 {
+        account_id: AccountId,
+        block_id: BlockId,
+    },
+    Variant1 {
+        account_id: AccountId,
+        finality: Finality,
+    },
+    Variant2 {
+        account_id: AccountId,
+        sync_checkpoint: SyncCheckpoint,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewAccountRequest {
+    fn from(value: &RpcViewAccountRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "A view of the account"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"description\": \"A view of the account\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"amount\","]
+#[doc = "    \"block_hash\","]
+#[doc = "    \"block_height\","]
+#[doc = "    \"code_hash\","]
+#[doc = "    \"locked\","]
+#[doc = "    \"storage_usage\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"amount\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/NearToken\""]
+#[doc = "    },"]
+#[doc = "    \"block_hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    },"]
+#[doc = "    \"block_height\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"code_hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    },"]
+#[doc = "    \"global_contract_account_id\": {"]
+#[doc = "      \"anyOf\": ["]
+#[doc = "        {"]
+#[doc = "          \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "        },"]
+#[doc = "        {"]
+#[doc = "          \"type\": \"null\""]
+#[doc = "        }"]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"global_contract_hash\": {"]
+#[doc = "      \"anyOf\": ["]
+#[doc = "        {"]
+#[doc = "          \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "        },"]
+#[doc = "        {"]
+#[doc = "          \"type\": \"null\""]
+#[doc = "        }"]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"locked\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/NearToken\""]
+#[doc = "    },"]
+#[doc = "    \"storage_paid_at\": {"]
+#[doc = "      \"description\": \"TODO(2271): deprecated.\","]
+#[doc = "      \"default\": 0,"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"storage_usage\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct RpcViewAccountResponse {
+    pub amount: NearToken,
+    pub block_hash: CryptoHash,
+    pub block_height: u64,
+    pub code_hash: CryptoHash,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub global_contract_account_id: ::std::option::Option<AccountId>,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub global_contract_hash: ::std::option::Option<CryptoHash>,
+    pub locked: NearToken,
+    #[doc = "TODO(2271): deprecated."]
+    #[serde(default)]
+    pub storage_paid_at: u64,
+    pub storage_usage: u64,
+}
+impl ::std::convert::From<&RpcViewAccountResponse> for RpcViewAccountResponse {
+    fn from(value: &RpcViewAccountResponse) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewCodeError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_reference\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_reference\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/BlockReference\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_BLOCK\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INVALID_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"contract_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"contract_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"NO_CONTRACT_CODE\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"error_message\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"error_message\": {"]
+#[doc = "              \"type\": \"string\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "info")]
+pub enum RpcViewCodeError {
+    #[serde(rename = "UNKNOWN_BLOCK")]
+    UnknownBlock { block_reference: BlockReference },
+    #[serde(rename = "INVALID_ACCOUNT")]
+    InvalidAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_ACCOUNT")]
+    UnknownAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "NO_CONTRACT_CODE")]
+    NoContractCode {
+        block_hash: CryptoHash,
+        block_height: u64,
+        contract_account_id: AccountId,
+    },
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError {
+        error_message: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewCodeError {
+    fn from(value: &RpcViewCodeError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewCodeRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"RpcViewCodeRequest\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"block_id\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"block_id\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/BlockId\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"finality\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"finality\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/Finality\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"sync_checkpoint\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"sync_checkpoint\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/SyncCheckpoint\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"account_id\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"account_id\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum RpcViewCodeRequest {
+    Variant0 {
+        account_id: AccountId,
+        block_id: BlockId,
+    },
+    Variant1 {
+        account_id: AccountId,
+        finality: Finality,
+    },
+    Variant2 {
+        account_id: AccountId,
+        sync_checkpoint: SyncCheckpoint,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewCodeRequest {
+    fn from(value: &RpcViewCodeRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "A view of the contract code."]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"description\": \"A view of the contract code.\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"block_hash\","]
+#[doc = "    \"block_height\","]
+#[doc = "    \"code_base64\","]
+#[doc = "    \"hash\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"block_hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    },"]
+#[doc = "    \"block_height\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"code_base64\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct RpcViewCodeResponse {
+    pub block_hash: CryptoHash,
+    pub block_height: u64,
+    pub code_base64: ::std::string::String,
+    pub hash: CryptoHash,
+}
+impl ::std::convert::From<&RpcViewCodeResponse> for RpcViewCodeResponse {
+    fn from(value: &RpcViewCodeResponse) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewGasKeyError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_reference\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_reference\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/BlockReference\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_BLOCK\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INVALID_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"public_key\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"public_key\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/PublicKey\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_GAS_KEY\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"error_message\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"error_message\": {"]
+#[doc = "              \"type\": \"string\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "info")]
+pub enum RpcViewGasKeyError {
+    #[serde(rename = "UNKNOWN_BLOCK")]
+    UnknownBlock { block_reference: BlockReference },
+    #[serde(rename = "INVALID_ACCOUNT")]
+    InvalidAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_ACCOUNT")]
+    UnknownAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_GAS_KEY")]
+    UnknownGasKey {
+        block_hash: CryptoHash,
+        block_height: u64,
+        public_key: PublicKey,
+    },
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError {
+        error_message: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewGasKeyError {
+    fn from(value: &RpcViewGasKeyError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewGasKeyListError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_reference\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_reference\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/BlockReference\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_BLOCK\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INVALID_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"error_message\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"error_message\": {"]
+#[doc = "              \"type\": \"string\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "info")]
+pub enum RpcViewGasKeyListError {
+    #[serde(rename = "UNKNOWN_BLOCK")]
+    UnknownBlock { block_reference: BlockReference },
+    #[serde(rename = "INVALID_ACCOUNT")]
+    InvalidAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_ACCOUNT")]
+    UnknownAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError {
+        error_message: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewGasKeyListError {
+    fn from(value: &RpcViewGasKeyListError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewGasKeyListRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"RpcViewGasKeyListRequest\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"block_id\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"block_id\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/BlockId\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"finality\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"finality\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/Finality\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"sync_checkpoint\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"sync_checkpoint\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/SyncCheckpoint\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"account_id\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"account_id\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum RpcViewGasKeyListRequest {
+    Variant0 {
+        account_id: AccountId,
+        block_id: BlockId,
+    },
+    Variant1 {
+        account_id: AccountId,
+        finality: Finality,
+    },
+    Variant2 {
+        account_id: AccountId,
+        sync_checkpoint: SyncCheckpoint,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewGasKeyListRequest {
+    fn from(value: &RpcViewGasKeyListRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewGasKeyListResponse`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"block_hash\","]
+#[doc = "    \"block_height\","]
+#[doc = "    \"keys\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"block_hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    },"]
+#[doc = "    \"block_height\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"keys\": {"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"$ref\": \"#/components/schemas/GasKeyInfoView\""]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct RpcViewGasKeyListResponse {
+    pub block_hash: CryptoHash,
+    pub block_height: u64,
+    pub keys: ::std::vec::Vec<GasKeyInfoView>,
+}
+impl ::std::convert::From<&RpcViewGasKeyListResponse> for RpcViewGasKeyListResponse {
+    fn from(value: &RpcViewGasKeyListResponse) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewGasKeyRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"RpcViewGasKeyRequest\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"block_id\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"block_id\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/BlockId\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"finality\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"finality\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/Finality\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"sync_checkpoint\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"sync_checkpoint\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/SyncCheckpoint\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"account_id\","]
+#[doc = "    \"public_key\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"account_id\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "    },"]
+#[doc = "    \"public_key\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/PublicKey\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum RpcViewGasKeyRequest {
+    Variant0 {
+        account_id: AccountId,
+        block_id: BlockId,
+        public_key: PublicKey,
+    },
+    Variant1 {
+        account_id: AccountId,
+        finality: Finality,
+        public_key: PublicKey,
+    },
+    Variant2 {
+        account_id: AccountId,
+        public_key: PublicKey,
+        sync_checkpoint: SyncCheckpoint,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewGasKeyRequest {
+    fn from(value: &RpcViewGasKeyRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewGasKeyResponse`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"balance\","]
+#[doc = "    \"block_hash\","]
+#[doc = "    \"block_height\","]
+#[doc = "    \"nonces\","]
+#[doc = "    \"num_nonces\","]
+#[doc = "    \"permission\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"balance\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/NearToken\""]
+#[doc = "    },"]
+#[doc = "    \"block_hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    },"]
+#[doc = "    \"block_height\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"nonces\": {"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"type\": \"integer\","]
+#[doc = "        \"format\": \"uint64\","]
+#[doc = "        \"minimum\": 0.0"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    \"num_nonces\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint32\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"permission\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccessKeyPermissionView\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct RpcViewGasKeyResponse {
+    pub balance: NearToken,
+    pub block_hash: CryptoHash,
+    pub block_height: u64,
+    pub nonces: ::std::vec::Vec<u64>,
+    pub num_nonces: u32,
+    pub permission: AccessKeyPermissionView,
+}
+impl ::std::convert::From<&RpcViewGasKeyResponse> for RpcViewGasKeyResponse {
+    fn from(value: &RpcViewGasKeyResponse) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewStateError`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_reference\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_reference\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/BlockReference\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_BLOCK\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INVALID_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"requested_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"requested_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"UNKNOWN_ACCOUNT\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"block_hash\","]
+#[doc = "            \"block_height\","]
+#[doc = "            \"contract_account_id\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"block_hash\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "            },"]
+#[doc = "            \"block_height\": {"]
+#[doc = "              \"type\": \"integer\","]
+#[doc = "              \"format\": \"uint64\","]
+#[doc = "              \"minimum\": 0.0"]
+#[doc = "            },"]
+#[doc = "            \"contract_account_id\": {"]
+#[doc = "              \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"TOO_LARGE_CONTRACT_STATE\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"info\","]
+#[doc = "        \"name\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"info\": {"]
+#[doc = "          \"type\": \"object\","]
+#[doc = "          \"required\": ["]
+#[doc = "            \"error_message\""]
+#[doc = "          ],"]
+#[doc = "          \"properties\": {"]
+#[doc = "            \"error_message\": {"]
+#[doc = "              \"type\": \"string\""]
+#[doc = "            }"]
+#[doc = "          }"]
+#[doc = "        },"]
+#[doc = "        \"name\": {"]
+#[doc = "          \"type\": \"string\","]
+#[doc = "          \"enum\": ["]
+#[doc = "            \"INTERNAL_ERROR\""]
+#[doc = "          ]"]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Debug,
+    thiserror::Error,
+    strum_macros::Display,
+)]
+#[serde(tag = "name", content = "info")]
+pub enum RpcViewStateError {
+    #[serde(rename = "UNKNOWN_BLOCK")]
+    UnknownBlock { block_reference: BlockReference },
+    #[serde(rename = "INVALID_ACCOUNT")]
+    InvalidAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "UNKNOWN_ACCOUNT")]
+    UnknownAccount {
+        block_hash: CryptoHash,
+        block_height: u64,
+        requested_account_id: AccountId,
+    },
+    #[serde(rename = "TOO_LARGE_CONTRACT_STATE")]
+    TooLargeContractState {
+        block_hash: CryptoHash,
+        block_height: u64,
+        contract_account_id: AccountId,
+    },
+    #[serde(rename = "INTERNAL_ERROR")]
+    InternalError {
+        error_message: ::std::string::String,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewStateError {
+    fn from(value: &RpcViewStateError) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`RpcViewStateRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"RpcViewStateRequest\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"block_id\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"block_id\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/BlockId\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"finality\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"finality\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/Finality\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"sync_checkpoint\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"sync_checkpoint\": {"]
+#[doc = "          \"$ref\": \"#/components/schemas/SyncCheckpoint\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ],"]
+#[doc = "  \"required\": ["]
+#[doc = "    \"account_id\","]
+#[doc = "    \"prefix_base64\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"account_id\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/AccountId\""]
+#[doc = "    },"]
+#[doc = "    \"include_proof\": {"]
+#[doc = "      \"default\": false,"]
+#[doc = "      \"type\": \"boolean\""]
+#[doc = "    },"]
+#[doc = "    \"prefix_base64\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/StoreKey\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum RpcViewStateRequest {
+    Variant0 {
+        account_id: AccountId,
+        block_id: BlockId,
+        #[serde(default)]
+        include_proof: bool,
+        prefix_base64: StoreKey,
+    },
+    Variant1 {
+        account_id: AccountId,
+        finality: Finality,
+        #[serde(default)]
+        include_proof: bool,
+        prefix_base64: StoreKey,
+    },
+    Variant2 {
+        account_id: AccountId,
+        #[serde(default)]
+        include_proof: bool,
+        prefix_base64: StoreKey,
+        sync_checkpoint: SyncCheckpoint,
+    },
+}
+impl ::std::convert::From<&Self> for RpcViewStateRequest {
+    fn from(value: &RpcViewStateRequest) -> Self {
+        value.clone()
+    }
+}
+#[doc = "Resulting state values for a view state query request"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"description\": \"Resulting state values for a view state query request\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"block_hash\","]
+#[doc = "    \"block_height\","]
+#[doc = "    \"values\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"block_hash\": {"]
+#[doc = "      \"$ref\": \"#/components/schemas/CryptoHash\""]
+#[doc = "    },"]
+#[doc = "    \"block_height\": {"]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"format\": \"uint64\","]
+#[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"proof\": {"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    \"values\": {"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"$ref\": \"#/components/schemas/StateItem\""]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct RpcViewStateResponse {
+    pub block_hash: CryptoHash,
+    pub block_height: u64,
+    #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
+    pub proof: ::std::vec::Vec<::std::string::String>,
+    pub values: ::std::vec::Vec<StateItem>,
+}
+impl ::std::convert::From<&RpcViewStateResponse> for RpcViewStateResponse {
+    fn from(value: &RpcViewStateResponse) -> Self {
+        value.clone()
     }
 }
 #[doc = "View that preserves JSON format of the runtime config."]

--- a/near-openapi-types/src/util.rs
+++ b/near-openapi-types/src/util.rs
@@ -10,15 +10,7 @@ use crate::error;
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CryptoHash(pub [u8; 32]);
 impl ::std::ops::Deref for CryptoHash {
     type Target = [u8; 32];

--- a/openapi.json
+++ b/openapi.json
@@ -5,6 +5,34 @@
         "version": "1.2.2"
     },
     "paths": {
+        "/EXPERIMENTAL_call_function": {
+            "post": {
+                "description": "Calls a view function on a contract and returns the result.",
+                "operationId": "EXPERIMENTAL_call_function",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_call_function"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonRpcResponse_for_RpcCallFunctionResponse_and_RpcCallFunctionError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/EXPERIMENTAL_changes": {
             "post": {
                 "description": "[Deprecated] Returns changes for a given account, contract or contract code for given block height or hash. Consider using changes instead.",
@@ -334,6 +362,202 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/JsonRpcResponse_for_Array_of_ValidatorStakeView_and_RpcValidatorError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/EXPERIMENTAL_view_access_key": {
+            "post": {
+                "description": "Returns information about a single access key for given account.",
+                "operationId": "EXPERIMENTAL_view_access_key",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_view_access_key"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonRpcResponse_for_RpcViewAccessKeyResponse_and_RpcViewAccessKeyError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/EXPERIMENTAL_view_access_key_list": {
+            "post": {
+                "description": "Returns all access keys for a given account.",
+                "operationId": "EXPERIMENTAL_view_access_key_list",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_view_access_key_list"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonRpcResponse_for_RpcViewAccessKeyListResponse_and_RpcViewAccessKeyListError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/EXPERIMENTAL_view_account": {
+            "post": {
+                "description": "Returns information about an account for given account_id.",
+                "operationId": "EXPERIMENTAL_view_account",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_view_account"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonRpcResponse_for_RpcViewAccountResponse_and_RpcViewAccountError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/EXPERIMENTAL_view_code": {
+            "post": {
+                "description": "Returns the contract code (Wasm binary) deployed to the account.",
+                "operationId": "EXPERIMENTAL_view_code",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_view_code"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonRpcResponse_for_RpcViewCodeResponse_and_RpcViewCodeError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/EXPERIMENTAL_view_gas_key": {
+            "post": {
+                "description": "Returns information about a single gas key for given account.",
+                "operationId": "EXPERIMENTAL_view_gas_key",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_view_gas_key"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonRpcResponse_for_RpcViewGasKeyResponse_and_RpcViewGasKeyError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/EXPERIMENTAL_view_gas_key_list": {
+            "post": {
+                "description": "Returns all gas keys for a given account.",
+                "operationId": "EXPERIMENTAL_view_gas_key_list",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_view_gas_key_list"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonRpcResponse_for_RpcViewGasKeyListResponse_and_RpcViewGasKeyListError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/EXPERIMENTAL_view_state": {
+            "post": {
+                "description": "Returns the state (key-value pairs) of a contract based on the key prefix.",
+                "operationId": "EXPERIMENTAL_view_state",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonRpcRequest_for_EXPERIMENTAL_view_state"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonRpcResponse_for_RpcViewStateResponse_and_RpcViewStateError"
                                 }
                             }
                         }
@@ -4277,6 +4501,64 @@
                     }
                 ]
             },
+            "ErrorWrapper_for_RpcCallFunctionError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcRequestValidationErrorKind"
+                            },
+                            "name": {
+                                "enum": [
+                                    "REQUEST_VALIDATION_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcCallFunctionError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "HANDLER_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/InternalError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
             "ErrorWrapper_for_RpcChunkError": {
                 "oneOf": [
                     {
@@ -5113,6 +5395,412 @@
                         "properties": {
                             "cause": {
                                 "$ref": "#/components/schemas/RpcValidatorError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "HANDLER_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/InternalError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ErrorWrapper_for_RpcViewAccessKeyError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcRequestValidationErrorKind"
+                            },
+                            "name": {
+                                "enum": [
+                                    "REQUEST_VALIDATION_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcViewAccessKeyError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "HANDLER_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/InternalError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ErrorWrapper_for_RpcViewAccessKeyListError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcRequestValidationErrorKind"
+                            },
+                            "name": {
+                                "enum": [
+                                    "REQUEST_VALIDATION_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcViewAccessKeyListError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "HANDLER_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/InternalError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ErrorWrapper_for_RpcViewAccountError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcRequestValidationErrorKind"
+                            },
+                            "name": {
+                                "enum": [
+                                    "REQUEST_VALIDATION_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcViewAccountError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "HANDLER_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/InternalError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ErrorWrapper_for_RpcViewCodeError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcRequestValidationErrorKind"
+                            },
+                            "name": {
+                                "enum": [
+                                    "REQUEST_VALIDATION_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcViewCodeError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "HANDLER_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/InternalError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ErrorWrapper_for_RpcViewGasKeyError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcRequestValidationErrorKind"
+                            },
+                            "name": {
+                                "enum": [
+                                    "REQUEST_VALIDATION_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcViewGasKeyError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "HANDLER_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/InternalError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ErrorWrapper_for_RpcViewGasKeyListError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcRequestValidationErrorKind"
+                            },
+                            "name": {
+                                "enum": [
+                                    "REQUEST_VALIDATION_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcViewGasKeyListError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "HANDLER_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/InternalError"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ErrorWrapper_for_RpcViewStateError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcRequestValidationErrorKind"
+                            },
+                            "name": {
+                                "enum": [
+                                    "REQUEST_VALIDATION_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "cause"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cause": {
+                                "$ref": "#/components/schemas/RpcViewStateError"
                             },
                             "name": {
                                 "enum": [
@@ -6903,10 +7591,28 @@
             "GlobalContractIdentifierView": {
                 "oneOf": [
                     {
-                        "$ref": "#/components/schemas/CryptoHash"
+                        "additionalProperties": false,
+                        "properties": {
+                            "hash": {
+                                "$ref": "#/components/schemas/CryptoHash"
+                            }
+                        },
+                        "required": [
+                            "hash"
+                        ],
+                        "type": "object"
                     },
                     {
-                        "$ref": "#/components/schemas/AccountId"
+                        "additionalProperties": false,
+                        "properties": {
+                            "account_id": {
+                                "$ref": "#/components/schemas/AccountId"
+                            }
+                        },
+                        "required": [
+                            "account_id"
+                        ],
+                        "type": "object"
                     }
                 ]
             },
@@ -8000,6 +8706,33 @@
                     }
                 ]
             },
+            "JsonRpcRequest_for_EXPERIMENTAL_call_function": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "enum": [
+                            "EXPERIMENTAL_call_function"
+                        ],
+                        "type": "string"
+                    },
+                    "params": {
+                        "$ref": "#/components/schemas/RpcCallFunctionRequest"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id",
+                    "params",
+                    "method"
+                ],
+                "title": "JsonRpcRequest_for_EXPERIMENTAL_call_function",
+                "type": "object"
+            },
             "JsonRpcRequest_for_EXPERIMENTAL_changes": {
                 "properties": {
                     "id": {
@@ -8322,6 +9055,195 @@
                     "method"
                 ],
                 "title": "JsonRpcRequest_for_EXPERIMENTAL_validators_ordered",
+                "type": "object"
+            },
+            "JsonRpcRequest_for_EXPERIMENTAL_view_access_key": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "enum": [
+                            "EXPERIMENTAL_view_access_key"
+                        ],
+                        "type": "string"
+                    },
+                    "params": {
+                        "$ref": "#/components/schemas/RpcViewAccessKeyRequest"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id",
+                    "params",
+                    "method"
+                ],
+                "title": "JsonRpcRequest_for_EXPERIMENTAL_view_access_key",
+                "type": "object"
+            },
+            "JsonRpcRequest_for_EXPERIMENTAL_view_access_key_list": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "enum": [
+                            "EXPERIMENTAL_view_access_key_list"
+                        ],
+                        "type": "string"
+                    },
+                    "params": {
+                        "$ref": "#/components/schemas/RpcViewAccessKeyListRequest"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id",
+                    "params",
+                    "method"
+                ],
+                "title": "JsonRpcRequest_for_EXPERIMENTAL_view_access_key_list",
+                "type": "object"
+            },
+            "JsonRpcRequest_for_EXPERIMENTAL_view_account": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "enum": [
+                            "EXPERIMENTAL_view_account"
+                        ],
+                        "type": "string"
+                    },
+                    "params": {
+                        "$ref": "#/components/schemas/RpcViewAccountRequest"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id",
+                    "params",
+                    "method"
+                ],
+                "title": "JsonRpcRequest_for_EXPERIMENTAL_view_account",
+                "type": "object"
+            },
+            "JsonRpcRequest_for_EXPERIMENTAL_view_code": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "enum": [
+                            "EXPERIMENTAL_view_code"
+                        ],
+                        "type": "string"
+                    },
+                    "params": {
+                        "$ref": "#/components/schemas/RpcViewCodeRequest"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id",
+                    "params",
+                    "method"
+                ],
+                "title": "JsonRpcRequest_for_EXPERIMENTAL_view_code",
+                "type": "object"
+            },
+            "JsonRpcRequest_for_EXPERIMENTAL_view_gas_key": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "enum": [
+                            "EXPERIMENTAL_view_gas_key"
+                        ],
+                        "type": "string"
+                    },
+                    "params": {
+                        "$ref": "#/components/schemas/RpcViewGasKeyRequest"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id",
+                    "params",
+                    "method"
+                ],
+                "title": "JsonRpcRequest_for_EXPERIMENTAL_view_gas_key",
+                "type": "object"
+            },
+            "JsonRpcRequest_for_EXPERIMENTAL_view_gas_key_list": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "enum": [
+                            "EXPERIMENTAL_view_gas_key_list"
+                        ],
+                        "type": "string"
+                    },
+                    "params": {
+                        "$ref": "#/components/schemas/RpcViewGasKeyListRequest"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id",
+                    "params",
+                    "method"
+                ],
+                "title": "JsonRpcRequest_for_EXPERIMENTAL_view_gas_key_list",
+                "type": "object"
+            },
+            "JsonRpcRequest_for_EXPERIMENTAL_view_state": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "enum": [
+                            "EXPERIMENTAL_view_state"
+                        ],
+                        "type": "string"
+                    },
+                    "params": {
+                        "$ref": "#/components/schemas/RpcViewStateRequest"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id",
+                    "params",
+                    "method"
+                ],
+                "title": "JsonRpcRequest_for_EXPERIMENTAL_view_state",
                 "type": "object"
             },
             "JsonRpcRequest_for_block": {
@@ -9093,6 +10015,46 @@
                 "title": "JsonRpcResponse_for_RpcBlockResponse_and_RpcBlockError",
                 "type": "object"
             },
+            "JsonRpcResponse_for_RpcCallFunctionResponse_and_RpcCallFunctionError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "result": {
+                                "$ref": "#/components/schemas/RpcCallFunctionResponse"
+                            }
+                        },
+                        "required": [
+                            "result"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "error": {
+                                "$ref": "#/components/schemas/ErrorWrapper_for_RpcCallFunctionError"
+                            }
+                        },
+                        "required": [
+                            "error"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id"
+                ],
+                "title": "JsonRpcResponse_for_RpcCallFunctionResponse_and_RpcCallFunctionError",
+                "type": "object"
+            },
             "JsonRpcResponse_for_RpcChunkResponse_and_RpcChunkError": {
                 "oneOf": [
                     {
@@ -9771,6 +10733,286 @@
                     "id"
                 ],
                 "title": "JsonRpcResponse_for_RpcValidatorResponse_and_RpcValidatorError",
+                "type": "object"
+            },
+            "JsonRpcResponse_for_RpcViewAccessKeyListResponse_and_RpcViewAccessKeyListError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "result": {
+                                "$ref": "#/components/schemas/RpcViewAccessKeyListResponse"
+                            }
+                        },
+                        "required": [
+                            "result"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "error": {
+                                "$ref": "#/components/schemas/ErrorWrapper_for_RpcViewAccessKeyListError"
+                            }
+                        },
+                        "required": [
+                            "error"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id"
+                ],
+                "title": "JsonRpcResponse_for_RpcViewAccessKeyListResponse_and_RpcViewAccessKeyListError",
+                "type": "object"
+            },
+            "JsonRpcResponse_for_RpcViewAccessKeyResponse_and_RpcViewAccessKeyError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "result": {
+                                "$ref": "#/components/schemas/RpcViewAccessKeyResponse"
+                            }
+                        },
+                        "required": [
+                            "result"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "error": {
+                                "$ref": "#/components/schemas/ErrorWrapper_for_RpcViewAccessKeyError"
+                            }
+                        },
+                        "required": [
+                            "error"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id"
+                ],
+                "title": "JsonRpcResponse_for_RpcViewAccessKeyResponse_and_RpcViewAccessKeyError",
+                "type": "object"
+            },
+            "JsonRpcResponse_for_RpcViewAccountResponse_and_RpcViewAccountError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "result": {
+                                "$ref": "#/components/schemas/RpcViewAccountResponse"
+                            }
+                        },
+                        "required": [
+                            "result"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "error": {
+                                "$ref": "#/components/schemas/ErrorWrapper_for_RpcViewAccountError"
+                            }
+                        },
+                        "required": [
+                            "error"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id"
+                ],
+                "title": "JsonRpcResponse_for_RpcViewAccountResponse_and_RpcViewAccountError",
+                "type": "object"
+            },
+            "JsonRpcResponse_for_RpcViewCodeResponse_and_RpcViewCodeError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "result": {
+                                "$ref": "#/components/schemas/RpcViewCodeResponse"
+                            }
+                        },
+                        "required": [
+                            "result"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "error": {
+                                "$ref": "#/components/schemas/ErrorWrapper_for_RpcViewCodeError"
+                            }
+                        },
+                        "required": [
+                            "error"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id"
+                ],
+                "title": "JsonRpcResponse_for_RpcViewCodeResponse_and_RpcViewCodeError",
+                "type": "object"
+            },
+            "JsonRpcResponse_for_RpcViewGasKeyListResponse_and_RpcViewGasKeyListError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "result": {
+                                "$ref": "#/components/schemas/RpcViewGasKeyListResponse"
+                            }
+                        },
+                        "required": [
+                            "result"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "error": {
+                                "$ref": "#/components/schemas/ErrorWrapper_for_RpcViewGasKeyListError"
+                            }
+                        },
+                        "required": [
+                            "error"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id"
+                ],
+                "title": "JsonRpcResponse_for_RpcViewGasKeyListResponse_and_RpcViewGasKeyListError",
+                "type": "object"
+            },
+            "JsonRpcResponse_for_RpcViewGasKeyResponse_and_RpcViewGasKeyError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "result": {
+                                "$ref": "#/components/schemas/RpcViewGasKeyResponse"
+                            }
+                        },
+                        "required": [
+                            "result"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "error": {
+                                "$ref": "#/components/schemas/ErrorWrapper_for_RpcViewGasKeyError"
+                            }
+                        },
+                        "required": [
+                            "error"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id"
+                ],
+                "title": "JsonRpcResponse_for_RpcViewGasKeyResponse_and_RpcViewGasKeyError",
+                "type": "object"
+            },
+            "JsonRpcResponse_for_RpcViewStateResponse_and_RpcViewStateError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "result": {
+                                "$ref": "#/components/schemas/RpcViewStateResponse"
+                            }
+                        },
+                        "required": [
+                            "result"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "error": {
+                                "$ref": "#/components/schemas/ErrorWrapper_for_RpcViewStateError"
+                            }
+                        },
+                        "required": [
+                            "error"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "jsonrpc": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "jsonrpc",
+                    "id"
+                ],
+                "title": "JsonRpcResponse_for_RpcViewStateResponse_and_RpcViewStateError",
                 "type": "object"
             },
             "KnownProducerView": {
@@ -11080,6 +12322,296 @@
                 ],
                 "type": "object"
             },
+            "RpcCallFunctionError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_reference": {
+                                        "$ref": "#/components/schemas/BlockReference"
+                                    }
+                                },
+                                "required": [
+                                    "block_reference"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_BLOCK"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INVALID_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "contract_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "contract_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "NO_CONTRACT_CODE"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "vm_error": {
+                                        "$ref": "#/components/schemas/FunctionCallError"
+                                    }
+                                },
+                                "required": [
+                                    "vm_error",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "CONTRACT_EXECUTION_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "error_message": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "error_message"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "RpcCallFunctionRequest": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "block_id": {
+                                "$ref": "#/components/schemas/BlockId"
+                            }
+                        },
+                        "required": [
+                            "block_id"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "finality": {
+                                "$ref": "#/components/schemas/Finality"
+                            }
+                        },
+                        "required": [
+                            "finality"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "sync_checkpoint": {
+                                "$ref": "#/components/schemas/SyncCheckpoint"
+                            }
+                        },
+                        "required": [
+                            "sync_checkpoint"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "account_id": {
+                        "$ref": "#/components/schemas/AccountId"
+                    },
+                    "args_base64": {
+                        "$ref": "#/components/schemas/FunctionArgs"
+                    },
+                    "method_name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "account_id",
+                    "method_name",
+                    "args_base64"
+                ],
+                "title": "RpcCallFunctionRequest",
+                "type": "object"
+            },
+            "RpcCallFunctionResponse": {
+                "description": "A result returned by contract method",
+                "properties": {
+                    "block_hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    },
+                    "block_height": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "logs": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "result": {
+                        "items": {
+                            "format": "uint8",
+                            "maximum": 255,
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "result",
+                    "logs",
+                    "block_height",
+                    "block_hash"
+                ],
+                "type": "object"
+            },
             "RpcChunkError": {
                 "oneOf": [
                     {
@@ -11406,10 +12938,6 @@
                         "maxItems": 2,
                         "minItems": 2,
                         "type": "array"
-                    },
-                    "dynamic_resharding_dry_run": {
-                        "description": "If true, the runtime will do a dynamic resharding 'dry run' at the last block of each epoch.\nThis means calculating tentative boundary accounts for splitting the tracked shards.",
-                        "type": "boolean"
                     },
                     "enable_early_prepare_transactions": {
                         "description": "If true, transactions for the next chunk will be prepared early, right after the previous chunk's\npost-state is ready. This can help produce chunks faster, for high-throughput chains.\nThe current implementation increases latency on low-load chains, which will be fixed in the future.\nThe default is disabled.",
@@ -13189,12 +14717,16 @@
                                         "minimum": 0,
                                         "type": "integer"
                                     },
+                                    "error": {
+                                        "$ref": "#/components/schemas/FunctionCallError"
+                                    },
                                     "vm_error": {
                                         "type": "string"
                                     }
                                 },
                                 "required": [
                                     "vm_error",
+                                    "error",
                                     "block_height",
                                     "block_hash"
                                 ],
@@ -16198,6 +17730,1634 @@
                     }
                 },
                 "title": "RpcValidatorsOrderedRequest",
+                "type": "object"
+            },
+            "RpcViewAccessKeyError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_reference": {
+                                        "$ref": "#/components/schemas/BlockReference"
+                                    }
+                                },
+                                "required": [
+                                    "block_reference"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_BLOCK"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INVALID_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "public_key": {
+                                        "$ref": "#/components/schemas/PublicKey"
+                                    }
+                                },
+                                "required": [
+                                    "public_key",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_ACCESS_KEY"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "error_message": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "error_message"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "RpcViewAccessKeyListError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_reference": {
+                                        "$ref": "#/components/schemas/BlockReference"
+                                    }
+                                },
+                                "required": [
+                                    "block_reference"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_BLOCK"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INVALID_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "error_message": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "error_message"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "RpcViewAccessKeyListRequest": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "block_id": {
+                                "$ref": "#/components/schemas/BlockId"
+                            }
+                        },
+                        "required": [
+                            "block_id"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "finality": {
+                                "$ref": "#/components/schemas/Finality"
+                            }
+                        },
+                        "required": [
+                            "finality"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "sync_checkpoint": {
+                                "$ref": "#/components/schemas/SyncCheckpoint"
+                            }
+                        },
+                        "required": [
+                            "sync_checkpoint"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "account_id": {
+                        "$ref": "#/components/schemas/AccountId"
+                    }
+                },
+                "required": [
+                    "account_id"
+                ],
+                "title": "RpcViewAccessKeyListRequest",
+                "type": "object"
+            },
+            "RpcViewAccessKeyListResponse": {
+                "description": "Lists access keys",
+                "properties": {
+                    "block_hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    },
+                    "block_height": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "keys": {
+                        "items": {
+                            "$ref": "#/components/schemas/AccessKeyInfoView"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "keys",
+                    "block_height",
+                    "block_hash"
+                ],
+                "type": "object"
+            },
+            "RpcViewAccessKeyRequest": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "block_id": {
+                                "$ref": "#/components/schemas/BlockId"
+                            }
+                        },
+                        "required": [
+                            "block_id"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "finality": {
+                                "$ref": "#/components/schemas/Finality"
+                            }
+                        },
+                        "required": [
+                            "finality"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "sync_checkpoint": {
+                                "$ref": "#/components/schemas/SyncCheckpoint"
+                            }
+                        },
+                        "required": [
+                            "sync_checkpoint"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "account_id": {
+                        "$ref": "#/components/schemas/AccountId"
+                    },
+                    "public_key": {
+                        "$ref": "#/components/schemas/PublicKey"
+                    }
+                },
+                "required": [
+                    "account_id",
+                    "public_key"
+                ],
+                "title": "RpcViewAccessKeyRequest",
+                "type": "object"
+            },
+            "RpcViewAccessKeyResponse": {
+                "description": "Describes access key permission scope and nonce.",
+                "properties": {
+                    "block_hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    },
+                    "block_height": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "nonce": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "permission": {
+                        "$ref": "#/components/schemas/AccessKeyPermissionView"
+                    }
+                },
+                "required": [
+                    "nonce",
+                    "permission",
+                    "block_height",
+                    "block_hash"
+                ],
+                "type": "object"
+            },
+            "RpcViewAccountError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_reference": {
+                                        "$ref": "#/components/schemas/BlockReference"
+                                    }
+                                },
+                                "required": [
+                                    "block_reference"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_BLOCK"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INVALID_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "error_message": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "error_message"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "RpcViewAccountRequest": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "block_id": {
+                                "$ref": "#/components/schemas/BlockId"
+                            }
+                        },
+                        "required": [
+                            "block_id"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "finality": {
+                                "$ref": "#/components/schemas/Finality"
+                            }
+                        },
+                        "required": [
+                            "finality"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "sync_checkpoint": {
+                                "$ref": "#/components/schemas/SyncCheckpoint"
+                            }
+                        },
+                        "required": [
+                            "sync_checkpoint"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "account_id": {
+                        "$ref": "#/components/schemas/AccountId"
+                    }
+                },
+                "required": [
+                    "account_id"
+                ],
+                "title": "RpcViewAccountRequest",
+                "type": "object"
+            },
+            "RpcViewAccountResponse": {
+                "description": "A view of the account",
+                "properties": {
+                    "amount": {
+                        "$ref": "#/components/schemas/NearToken"
+                    },
+                    "block_hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    },
+                    "block_height": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "code_hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    },
+                    "global_contract_account_id": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/AccountId"
+                            },
+                            {
+                                "enum": [
+                                    null
+                                ],
+                                "nullable": true
+                            }
+                        ]
+                    },
+                    "global_contract_hash": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/CryptoHash"
+                            },
+                            {
+                                "enum": [
+                                    null
+                                ],
+                                "nullable": true
+                            }
+                        ]
+                    },
+                    "locked": {
+                        "$ref": "#/components/schemas/NearToken"
+                    },
+                    "storage_paid_at": {
+                        "default": 0,
+                        "description": "TODO(2271): deprecated.",
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "storage_usage": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "amount",
+                    "locked",
+                    "code_hash",
+                    "storage_usage",
+                    "block_height",
+                    "block_hash"
+                ],
+                "type": "object"
+            },
+            "RpcViewCodeError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_reference": {
+                                        "$ref": "#/components/schemas/BlockReference"
+                                    }
+                                },
+                                "required": [
+                                    "block_reference"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_BLOCK"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INVALID_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "contract_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "contract_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "NO_CONTRACT_CODE"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "error_message": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "error_message"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "RpcViewCodeRequest": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "block_id": {
+                                "$ref": "#/components/schemas/BlockId"
+                            }
+                        },
+                        "required": [
+                            "block_id"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "finality": {
+                                "$ref": "#/components/schemas/Finality"
+                            }
+                        },
+                        "required": [
+                            "finality"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "sync_checkpoint": {
+                                "$ref": "#/components/schemas/SyncCheckpoint"
+                            }
+                        },
+                        "required": [
+                            "sync_checkpoint"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "account_id": {
+                        "$ref": "#/components/schemas/AccountId"
+                    }
+                },
+                "required": [
+                    "account_id"
+                ],
+                "title": "RpcViewCodeRequest",
+                "type": "object"
+            },
+            "RpcViewCodeResponse": {
+                "description": "A view of the contract code.",
+                "properties": {
+                    "block_hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    },
+                    "block_height": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "code_base64": {
+                        "type": "string"
+                    },
+                    "hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    }
+                },
+                "required": [
+                    "code_base64",
+                    "hash",
+                    "block_height",
+                    "block_hash"
+                ],
+                "type": "object"
+            },
+            "RpcViewGasKeyError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_reference": {
+                                        "$ref": "#/components/schemas/BlockReference"
+                                    }
+                                },
+                                "required": [
+                                    "block_reference"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_BLOCK"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INVALID_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "public_key": {
+                                        "$ref": "#/components/schemas/PublicKey"
+                                    }
+                                },
+                                "required": [
+                                    "public_key",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_GAS_KEY"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "error_message": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "error_message"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "RpcViewGasKeyListError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_reference": {
+                                        "$ref": "#/components/schemas/BlockReference"
+                                    }
+                                },
+                                "required": [
+                                    "block_reference"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_BLOCK"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INVALID_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "error_message": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "error_message"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "RpcViewGasKeyListRequest": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "block_id": {
+                                "$ref": "#/components/schemas/BlockId"
+                            }
+                        },
+                        "required": [
+                            "block_id"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "finality": {
+                                "$ref": "#/components/schemas/Finality"
+                            }
+                        },
+                        "required": [
+                            "finality"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "sync_checkpoint": {
+                                "$ref": "#/components/schemas/SyncCheckpoint"
+                            }
+                        },
+                        "required": [
+                            "sync_checkpoint"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "account_id": {
+                        "$ref": "#/components/schemas/AccountId"
+                    }
+                },
+                "required": [
+                    "account_id"
+                ],
+                "title": "RpcViewGasKeyListRequest",
+                "type": "object"
+            },
+            "RpcViewGasKeyListResponse": {
+                "properties": {
+                    "block_hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    },
+                    "block_height": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "keys": {
+                        "items": {
+                            "$ref": "#/components/schemas/GasKeyInfoView"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "keys",
+                    "block_height",
+                    "block_hash"
+                ],
+                "type": "object"
+            },
+            "RpcViewGasKeyRequest": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "block_id": {
+                                "$ref": "#/components/schemas/BlockId"
+                            }
+                        },
+                        "required": [
+                            "block_id"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "finality": {
+                                "$ref": "#/components/schemas/Finality"
+                            }
+                        },
+                        "required": [
+                            "finality"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "sync_checkpoint": {
+                                "$ref": "#/components/schemas/SyncCheckpoint"
+                            }
+                        },
+                        "required": [
+                            "sync_checkpoint"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "account_id": {
+                        "$ref": "#/components/schemas/AccountId"
+                    },
+                    "public_key": {
+                        "$ref": "#/components/schemas/PublicKey"
+                    }
+                },
+                "required": [
+                    "account_id",
+                    "public_key"
+                ],
+                "title": "RpcViewGasKeyRequest",
+                "type": "object"
+            },
+            "RpcViewGasKeyResponse": {
+                "properties": {
+                    "balance": {
+                        "$ref": "#/components/schemas/NearToken"
+                    },
+                    "block_hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    },
+                    "block_height": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "nonces": {
+                        "items": {
+                            "format": "uint64",
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        "type": "array"
+                    },
+                    "num_nonces": {
+                        "format": "uint32",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "permission": {
+                        "$ref": "#/components/schemas/AccessKeyPermissionView"
+                    }
+                },
+                "required": [
+                    "num_nonces",
+                    "balance",
+                    "permission",
+                    "nonces",
+                    "block_height",
+                    "block_hash"
+                ],
+                "type": "object"
+            },
+            "RpcViewStateError": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_reference": {
+                                        "$ref": "#/components/schemas/BlockReference"
+                                    }
+                                },
+                                "required": [
+                                    "block_reference"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_BLOCK"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INVALID_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "requested_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "requested_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "UNKNOWN_ACCOUNT"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "block_hash": {
+                                        "$ref": "#/components/schemas/CryptoHash"
+                                    },
+                                    "block_height": {
+                                        "format": "uint64",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "contract_account_id": {
+                                        "$ref": "#/components/schemas/AccountId"
+                                    }
+                                },
+                                "required": [
+                                    "contract_account_id",
+                                    "block_height",
+                                    "block_hash"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "TOO_LARGE_CONTRACT_STATE"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "info": {
+                                "properties": {
+                                    "error_message": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "error_message"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "enum": [
+                                    "INTERNAL_ERROR"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "info"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "RpcViewStateRequest": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "block_id": {
+                                "$ref": "#/components/schemas/BlockId"
+                            }
+                        },
+                        "required": [
+                            "block_id"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "finality": {
+                                "$ref": "#/components/schemas/Finality"
+                            }
+                        },
+                        "required": [
+                            "finality"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "sync_checkpoint": {
+                                "$ref": "#/components/schemas/SyncCheckpoint"
+                            }
+                        },
+                        "required": [
+                            "sync_checkpoint"
+                        ],
+                        "type": "object"
+                    }
+                ],
+                "properties": {
+                    "account_id": {
+                        "$ref": "#/components/schemas/AccountId"
+                    },
+                    "include_proof": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "prefix_base64": {
+                        "$ref": "#/components/schemas/StoreKey"
+                    }
+                },
+                "required": [
+                    "account_id",
+                    "prefix_base64"
+                ],
+                "title": "RpcViewStateRequest",
+                "type": "object"
+            },
+            "RpcViewStateResponse": {
+                "description": "Resulting state values for a view state query request",
+                "properties": {
+                    "block_hash": {
+                        "$ref": "#/components/schemas/CryptoHash"
+                    },
+                    "block_height": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "proof": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "values": {
+                        "items": {
+                            "$ref": "#/components/schemas/StateItem"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "values",
+                    "block_height",
+                    "block_hash"
+                ],
                 "type": "object"
             },
             "RuntimeConfigView": {


### PR DESCRIPTION
## Summary
- Merges the automated regeneration from `create-pull-request/patch` (Dec 23 2025) which picks up the [fixed OpenAPI spec from nearcore](https://github.com/near/nearcore/commit/2eba640ae) 
- Fixes `GlobalContractIdentifierView` — was incorrectly generated as `#[serde(untagged)]` with bare string variants, now correctly uses externally tagged enum matching what nearcore actually returns (`{"hash": "..."}` / `{"account_id": "..."}`)
- Fixes broken doctests in client lib.rs (wrong language tags, outdated type names, missing async wrapper)

Resolves the deserialization failure reported for transactions containing `DeterministicStateInit` actions (see [near-api-rs discussion](https://github.com/near/near-api-rs/issues/127)).

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (all doctests fixed)
- [ ] Verify near-api-rs works with updated types