### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/polyprogrammist/near-openapi-client"
@@ -10,4 +10,4 @@ resolver = "3"
 
 [workspace.dependencies]
 near-openapi-client = { path = "near-openapi-client" }
-near-openapi-types = { path = "near-openapi-types", version = "0.7.0" }
+near-openapi-types = { path = "near-openapi-types", version = "0.8.0" }

--- a/near-openapi-client/CHANGELOG.md
+++ b/near-openapi-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/near/near-openapi-client-rs/compare/near-openapi-client-v0.7.0...near-openapi-client-v0.8.0) - 2026-03-04
+
+### Fixed
+
+- regenerate types from Dec 23 OpenAPI spec ([#41](https://github.com/near/near-openapi-client-rs/pull/41))
+
 ## [0.7.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-client-v0.6.0...near-openapi-client-v0.7.0) - 2025-12-18
 
 ### Fixed

--- a/near-openapi-types/CHANGELOG.md
+++ b/near-openapi-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/near/near-openapi-client-rs/compare/near-openapi-types-v0.7.0...near-openapi-types-v0.8.0) - 2026-03-04
+
+### Fixed
+
+- regenerate types from Dec 23 OpenAPI spec ([#41](https://github.com/near/near-openapi-client-rs/pull/41))
+
 ## [0.7.0](https://github.com/PolyProgrammist/near-openapi-client/compare/near-openapi-types-v0.6.0...near-openapi-types-v0.7.0) - 2025-12-18
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `near-openapi-types`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `near-openapi-client`: 0.7.0 -> 0.8.0 (✓ API compatible changes)

### ⚠ `near-openapi-types` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field error of variant RpcQueryError::ContractExecutionError in /tmp/.tmptRynjc/near-openapi-client-rs/near-openapi-types/src/lib.rs:26782

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant GlobalContractIdentifierView:Hash in /tmp/.tmptRynjc/near-openapi-client-rs/near-openapi-types/src/lib.rs:12066

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant GlobalContractIdentifierView::CryptoHash, previously in file /tmp/.tmpNxbt3Z/near-openapi-types/src/lib.rs:11230

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field dynamic_resharding_dry_run of struct RpcClientConfigResponse, previously in file /tmp/.tmpNxbt3Z/near-openapi-types/src/lib.rs:21308
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-openapi-types`

<blockquote>

## [0.8.0](https://github.com/near/near-openapi-client-rs/compare/near-openapi-types-v0.7.0...near-openapi-types-v0.8.0) - 2026-03-04

### Fixed

- regenerate types from Dec 23 OpenAPI spec ([#41](https://github.com/near/near-openapi-client-rs/pull/41))
</blockquote>

## `near-openapi-client`

<blockquote>

## [0.8.0](https://github.com/near/near-openapi-client-rs/compare/near-openapi-client-v0.7.0...near-openapi-client-v0.8.0) - 2026-03-04

### Fixed

- regenerate types from Dec 23 OpenAPI spec ([#41](https://github.com/near/near-openapi-client-rs/pull/41))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).