### PR TITLE
ci: trusted publishing to crates.io via release-plz + OIDC

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,33 +1,76 @@
 name: Release-plz
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   push:
     branches:
       - main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-  release-plz:
-    name: Release-plz
+  release-plz-pr:
+    name: Release-plz PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz (release-pr)
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write
+      attestations: write
+    # Never cancel an in-flight publish — half-published releases are worse than waiting.
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Install packages (Linux)
-        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install --assume-yes libudev-dev
-      - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+      - name: Run release-plz (release)
+        id: release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
         env:
-          # https://release-plz.ieni.dev/docs/github/quickstart
-          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # release-plz doesn't expose the produced .crate paths, so re-package locally.
+      # The crate tarballs are reproducible from the same commit, so the attestations
+      # still bind the published artifacts to this run. Packages all workspace members.
+      - name: Re-package crates for attestation
+        if: steps.release-plz.outputs.releases_created == 'true'
+        run: cargo package --workspace --no-verify
+      - name: Attest build provenance
+        if: steps.release-plz.outputs.releases_created == 'true'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: target/package/*.crate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.8.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/polyprogrammist/near-openapi-client"
+repository = "https://github.com/near/near-openapi-client-rs"
 
 [workspace]
 members = ["near-openapi-client", "near-openapi-types"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,14 @@
+[workspace]
+changelog_update = true
+git_tag_enable = true
+git_release_enable = true
+git_release_type = "auto"
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""


### PR DESCRIPTION
OIDC trusted publishing via release-plz. Drops `CARGO_REGISTRY_TOKEN` and the `NEARPROTOCOL_CI_PR_ACCESS` PAT, adds attestations. Pattern matches near/near-slip10#3.

Workspace has two published crates, so **both** need crates.io trusted publisher registration before the next release: `near-openapi-client` and `near-openapi-types` (workflow file `release-plz.yml` for both).

Also fixed a stale `repository` URL in the workspace metadata (was pointing at `polyprogrammist/near-openapi-client`).

Refs near/devex#45